### PR TITLE
Lrci 1398 second batch FOR REAL

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
@@ -418,6 +418,15 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 
 	protected JobProperty getJobProperty(
 		String basePropertyName, String testSuiteName, String testBatchName,
+		File testBaseDir, JobProperty.Type type) {
+
+		return _getJobProperty(
+			basePropertyName, testSuiteName, testBatchName, testBaseDir, type,
+			true);
+	}
+
+	protected JobProperty getJobProperty(
+		String basePropertyName, String testSuiteName, String testBatchName,
 		JobProperty.Type type) {
 
 		return _getJobProperty(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/FunctionalBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/FunctionalBatchTestClassGroup.java
@@ -14,8 +14,6 @@
 
 package com.liferay.jenkins.results.parser.test.clazz.group;
 
-import com.google.common.collect.Lists;
-
 import com.liferay.jenkins.results.parser.AntException;
 import com.liferay.jenkins.results.parser.AntUtil;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
@@ -340,46 +338,6 @@ public class FunctionalBatchTestClassGroup extends BatchTestClassGroup {
 		return getDefaultTestBatchRunPropertyQuery(testBaseDir, testSuiteName);
 	}
 
-	private List<File> _getFunctionalRequiredModuleDirs(List<File> moduleDirs) {
-		List<File> functionalRequiredModuleDirs = Lists.newArrayList(
-			moduleDirs);
-
-		File modulesBaseDir = new File(
-			portalGitWorkingDirectory.getWorkingDirectory(), "modules");
-
-		for (File moduleDir : moduleDirs) {
-			JobProperty jobProperty = getJobProperty(
-				"modules.includes.required.functional", moduleDir,
-				JobProperty.Type.MODULE_TEST_DIR);
-
-			String jobPropertyValue = jobProperty.getValue();
-
-			if (jobPropertyValue == null) {
-				continue;
-			}
-
-			recordJobProperty(jobProperty);
-
-			for (String functionalRequiredModuleDirPath :
-					jobPropertyValue.split(",")) {
-
-				File functionalRequiredModuleDir = new File(
-					modulesBaseDir, functionalRequiredModuleDirPath);
-
-				if (!functionalRequiredModuleDir.exists() ||
-					functionalRequiredModuleDirs.contains(
-						functionalRequiredModuleDir)) {
-
-					continue;
-				}
-
-				functionalRequiredModuleDirs.add(functionalRequiredModuleDir);
-			}
-		}
-
-		return Lists.newArrayList(functionalRequiredModuleDirs);
-	}
-
 	private String _getTestBatchRunPropertyQuery(File testBaseDir) {
 		if (!testRelevantChanges) {
 			return getDefaultTestBatchRunPropertyQuery(
@@ -404,9 +362,7 @@ public class FunctionalBatchTestClassGroup extends BatchTestClassGroup {
 				continue;
 			}
 
-			if (!sbToString.contains(testBatchPQL) &&
-				!testBatchPQL.equals("false")) {
-
+			if (!sbToString.contains(testBatchPQL)) {
 				if (!JenkinsResultsParserUtil.isNullOrEmpty(sbToString)) {
 					sb.append(" OR ");
 				}
@@ -428,9 +384,7 @@ public class FunctionalBatchTestClassGroup extends BatchTestClassGroup {
 
 			sb.append(" OR (");
 
-			sb.append(
-				getDefaultTestBatchRunPropertyQuery(
-					testBaseDir, testSuiteName));
+			sb.append(defaultPQL);
 
 			sb.append(")");
 
@@ -456,7 +410,6 @@ public class FunctionalBatchTestClassGroup extends BatchTestClassGroup {
 
 				recordJobProperty(jobProperty);
 
-				System.out.println("ADDING MORE ORs......");
 				sb.append(" OR (");
 				sb.append(jobPropertyValue);
 				sb.append(")");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/FunctionalBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/FunctionalBatchTestClassGroup.java
@@ -361,8 +361,8 @@ public class FunctionalBatchTestClassGroup extends BatchTestClassGroup {
 				continue;
 			}
 
-			if (!sbToString.contains(testBatchPQL)) {
-				if (!JenkinsResultsParserUtil.isNullOrEmpty(sbToString)) {
+			if (!(sb.indexOf(testBatchPQL) > -1)) {
+				if (!JenkinsResultsParserUtil.isNullOrEmpty(sb.toString())) {
 					sb.append(" OR ");
 				}
 
@@ -381,7 +381,11 @@ public class FunctionalBatchTestClassGroup extends BatchTestClassGroup {
 		if (!JenkinsResultsParserUtil.isNullOrEmpty(defaultPQL) &&
 			!sbToString.contains(defaultPQL)) {
 
-			sb.append(" OR (");
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(sbToString)) {
+				sb.append(" OR ");
+			}
+
+			sb.append("(");
 
 			sb.append(defaultPQL);
 
@@ -409,7 +413,11 @@ public class FunctionalBatchTestClassGroup extends BatchTestClassGroup {
 
 				recordJobProperty(jobProperty);
 
-				sb.append(" OR (");
+				if (!JenkinsResultsParserUtil.isNullOrEmpty(sb.toString())) {
+					sb.append(" OR ");
+				}
+
+				sb.append("(");
 				sb.append(jobPropertyValue);
 				sb.append(")");
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/FunctionalBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/FunctionalBatchTestClassGroup.java
@@ -308,6 +308,12 @@ public class FunctionalBatchTestClassGroup extends BatchTestClassGroup {
 			return _concatPQL(parentFile, testBaseDir, concatedPQL);
 		}
 
+		if (_traversedPropertyFiles.contains(testPropertiesFile)) {
+			return concatedPQL;
+		}
+
+		_traversedPropertyFiles.add(testPropertiesFile);
+
 		JobProperty jobProperty = getJobProperty(
 			"test.batch.run.property.query", getTestSuiteName(), batchName,
 			canonicalFile, JobProperty.Type.MODULE_TEST_DIR);
@@ -457,13 +463,11 @@ public class FunctionalBatchTestClassGroup extends BatchTestClassGroup {
 		}
 	}
 
-	// 	private static final String _combinedTestBatchRunPropertyQuery =
-
-	//		new String();
 	private static final Pattern _poshiTestCasePattern = Pattern.compile(
 		"(?<namespace>[^\\.]+)\\.(?<className>[^\\#]+)\\#(?<methodName>.*)");
 
 	private final Map<File, String> _testBatchRunPropertyQueries =
 		new HashMap<>();
+	private final Set<File> _traversedPropertyFiles = new HashSet<>();
 
 }


### PR DESCRIPTION
LPS-135170 Add integration test
LPS-135170 - Add portlet to draftLayout and publish before testing.
LPS-135170 - Test portlets with preferences owned by group.
LPS-135170 - Test portlets on widget pages.
LPS-135170 - Add test util for deleting portlets from content pages.
LPS-135170 - For content pages, test that getPlidFromPortletId does not return the page after the portlet is removed from it.
LPS-135170 - Baseline