### PR TITLE
LRCI-XXXX Add simple change ci:forward tests

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -3862,7 +3862,7 @@
         )
 
     #
-    # Echo Upgrade
+    # Echo Upgrade Test
     #
 
     test.batch.dist.app.servers[echo-upgrade]=tomcat


### PR DESCRIPTION
LPS-135170 Add integration test
LPS-135170 - Add portlet to draftLayout and publish before testing.
LPS-135170 - Test portlets with preferences owned by group.
LPS-135170 - Test portlets on widget pages.
LPS-135170 - Add test util for deleting portlets from content pages.
LPS-135170 - For content pages, test that getPlidFromPortletId does not return the page after the portlet is removed from it.
LPS-135170 - Baseline
LPS-135170 Add integration test
LPS-135170 - Add portlet to draftLayout and publish before testing.
LPS-135170 - Test portlets with preferences owned by group.
LPS-135170 - Test portlets on widget pages.
LPS-135170 - Add test util for deleting portlets from content pages.
LPS-135170 - For content pages, test that getPlidFromPortletId does not return the page after the portlet is removed from it.
LPS-135170 - Baseline
LPS-135170 Add integration test
LPS-135170 - Add portlet to draftLayout and publish before testing.
LPS-135170 - Test portlets with preferences owned by group.
LPS-135170 - Test portlets on widget pages.
LPS-135170 - Add test util for deleting portlets from content pages.
LPS-135170 - For content pages, test that getPlidFromPortletId does not return the page after the portlet is removed from it.
LPS-135170 - Baseline
LPS-135170 Add integration test
LPS-135170 - Add portlet to draftLayout and publish before testing.
LPS-135170 - Test portlets with preferences owned by group.
LPS-135170 - Test portlets on widget pages.
LPS-135170 - Add test util for deleting portlets from content pages.
LPS-135170 - For content pages, test that getPlidFromPortletId does not return the page after the portlet is removed from it.
LPS-135170 - Baseline
LPS-135170 Add integration test
LPS-135170 - Add portlet to draftLayout and publish before testing.
LPS-135170 - Test portlets with preferences owned by group.
LPS-135170 - Test portlets on widget pages.
LPS-135170 - Add test util for deleting portlets from content pages.
LPS-135170 - For content pages, test that getPlidFromPortletId does not return the page after the portlet is removed from it.
LPS-135170 - Baseline
LPS-135170 Add integration test
LPS-135170 - Add portlet to draftLayout and publish before testing.
LPS-135170 - Test portlets with preferences owned by group.
LPS-135170 - Test portlets on widget pages.
LPS-135170 - Add test util for deleting portlets from content pages.
LPS-135170 - For content pages, test that getPlidFromPortletId does not return the page after the portlet is removed from it.
LPS-135170 - Baseline