### PR TITLE
LRCI-7532 Simplify LoadBalancer with round-robin selection for AWS dynamic-slave CI

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ArchiveBinariesCachePortalControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ArchiveBinariesCachePortalControllerBuildRunner.java
@@ -143,7 +143,7 @@ public class ArchiveBinariesCachePortalControllerBuildRunner
 
 		String masterURL = JenkinsResultsParserUtil.getMostAvailableMasterURL(
 			"http://" + getInvocationCohortName() + ".liferay.com", null, 1,
-			invocationJobName, _SLAVE_LABEL, 24, 2);
+			invocationJobName);
 
 		return JenkinsResultsParserUtil.getRemoteURL(
 			JenkinsResultsParserUtil.combine(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildRunner.java
@@ -64,36 +64,6 @@ public abstract class BaseBuildRunner<T extends BuildData>
 		return _job;
 	}
 
-	protected String getLabelExpression(String jobName) {
-		String labelExpression = null;
-
-		try {
-			labelExpression = JenkinsResultsParserUtil.getBuildProperty(
-				"jenkins.osb.jenkins.web.slave.label", jobName);
-
-			if (JenkinsResultsParserUtil.isNullOrEmpty(labelExpression)) {
-				labelExpression = JenkinsResultsParserUtil.getBuildProperty(
-					"jenkins.osb.jenkins.web.slave.label.minimum.ram",
-					String.valueOf(getSlaveRAMMinimum()));
-			}
-
-			if (JenkinsResultsParserUtil.isNullOrEmpty(labelExpression)) {
-				labelExpression = JenkinsResultsParserUtil.getBuildProperty(
-					"cloud.fleet.primary.label");
-			}
-
-			if (JenkinsResultsParserUtil.isNullOrEmpty(labelExpression)) {
-				labelExpression = JenkinsResultsParserUtil.getBuildProperty(
-					"master.auto.scaling.group.name");
-			}
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
-
-		return labelExpression;
-	}
-
 	protected List<JSONObject> getPreviousBuildJSONObjects() {
 		if (_previousBuildJSONObjects != null) {
 			return _previousBuildJSONObjects;
@@ -124,10 +94,6 @@ public abstract class BaseBuildRunner<T extends BuildData>
 		}
 
 		return _previousBuildJSONObjects;
-	}
-
-	protected int getSlaveRAMMinimum() {
-		return JenkinsMaster.getSlaveRAMMinimumDefault();
 	}
 
 	protected void keepJenkinsBuild(boolean keepLogs) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseUpstreamPortalControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseUpstreamPortalControllerBuildRunner.java
@@ -37,7 +37,7 @@ public abstract class BaseUpstreamPortalControllerBuildRunner
 		if (masterURL == null) {
 			masterURL = JenkinsResultsParserUtil.getMostAvailableMasterURL(
 				"http://" + getInvocationCohortName() + ".liferay.com", null, 1,
-				invocationJobName, getSlaveLabel(testSuite), 24, 2);
+				invocationJobName);
 		}
 
 		return JenkinsResultsParserUtil.combine(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultBuildUpdater.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultBuildUpdater.java
@@ -5,8 +5,6 @@
 
 package com.liferay.jenkins.results.parser;
 
-import com.liferay.jenkins.results.parser.test.clazz.group.AxisTestClassGroup;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -31,9 +29,7 @@ public class DefaultBuildUpdater extends BaseBuildUpdater {
 			JenkinsCohort jenkinsCohort = build.getJenkinsCohort();
 
 			jenkinsMaster = jenkinsCohort.getMostAvailableJenkinsMaster(
-				build.getInvokedBatchSize(), build.getJobName(),
-				_getLabelExpression(), build.getMinimumSlaveRAM(),
-				build.getMaximumSlavesPerHost());
+				build.getInvokedBatchSize(), build.getJobName());
 
 			build.setJenkinsMaster(jenkinsMaster);
 		}
@@ -53,8 +49,7 @@ public class DefaultBuildUpdater extends BaseBuildUpdater {
 
 		JenkinsMaster jenkinsMaster =
 			jenkinsCohort.getMostAvailableJenkinsMaster(
-				build.getInvokedBatchSize(), build.getJobName(),
-				_getLabelExpression(), 24, build.getMaximumSlavesPerHost());
+				build.getInvokedBatchSize(), build.getJobName());
 
 		build.setJenkinsMaster(jenkinsMaster);
 
@@ -290,31 +285,6 @@ public class DefaultBuildUpdater extends BaseBuildUpdater {
 		}
 
 		return buildParameters;
-	}
-
-	private String _getLabelExpression() {
-		Build build = getBuild();
-
-		Map<String, String> buildParameters = build.getParameters();
-
-		String slaveLabel = buildParameters.get("SLAVE_LABEL");
-
-		if (!JenkinsResultsParserUtil.isNullOrEmpty(slaveLabel)) {
-			return slaveLabel;
-		}
-
-		if (build instanceof DownstreamBuild) {
-			DownstreamBuild downstreamBuild = (DownstreamBuild)build;
-
-			AxisTestClassGroup axisTestClassGroup =
-				downstreamBuild.getAxisTestClassGroup();
-
-			if (axisTestClassGroup != null) {
-				return axisTestClassGroup.getSlaveLabel();
-			}
-		}
-
-		return null;
 	}
 
 	private JSONObject _getQueueItemJSONObject() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -91,15 +91,13 @@ public class JenkinsCohort {
 	}
 
 	public JenkinsMaster getMostAvailableJenkinsMaster(
-		int invokedBatchSize, String jobName, String labelExpression,
-		int minimumRAM, int maximumSlavesPerHost) {
+		int invokedBatchSize, String jobName) {
 
 		String mostAvailableMasterURL =
 			JenkinsResultsParserUtil.getMostAvailableMasterURL(
 				"http://" + getName() + ".liferay.com",
 				JenkinsResultsParserUtil.join(",", _jenkinsMastersBlacklist),
-				invokedBatchSize, jobName, labelExpression, minimumRAM,
-				maximumSlavesPerHost);
+				invokedBatchSize, jobName);
 
 		return JenkinsMaster.getInstance(
 			mostAvailableMasterURL.replaceAll("http://(.+)", "$1"));

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -2908,25 +2908,20 @@ public class JenkinsResultsParserUtil {
 	}
 
 	public static JenkinsMaster getMostAvailableJenkinsMaster(
-		String baseInvocationURL, int invokedBatchSize,
-		String labelExpression) {
+		String baseInvocationURL, int invokedBatchSize) {
 
 		String mostAvailableMasterURL = getMostAvailableMasterURL(
-			baseInvocationURL, null, invokedBatchSize, null, labelExpression,
-			JenkinsMaster.getSlaveRAMMinimumDefault(),
-			JenkinsMaster.getSlavesPerHostDefault());
+			baseInvocationURL, null, invokedBatchSize);
 
 		return JenkinsMaster.getInstance(
 			mostAvailableMasterURL.replaceAll("http://(.+)", "$1"));
 	}
 
 	public static JenkinsMaster getMostAvailableJenkinsMaster(
-		String baseInvocationURL, String blacklist, int invokedBatchSize,
-		int minimumRAM, int maximumSlavesPerHost) {
+		String baseInvocationURL, String blacklist, int invokedBatchSize) {
 
 		String mostAvailableMasterURL = getMostAvailableMasterURL(
-			baseInvocationURL, blacklist, invokedBatchSize, minimumRAM,
-			maximumSlavesPerHost);
+			baseInvocationURL, blacklist, invokedBatchSize);
 
 		return JenkinsMaster.getInstance(
 			mostAvailableMasterURL.replaceAll("http://(.+)", "$1"));
@@ -2936,42 +2931,19 @@ public class JenkinsResultsParserUtil {
 		String baseInvocationURL, int invokedBatchSize) {
 
 		return getMostAvailableMasterURL(
-			baseInvocationURL, null, invokedBatchSize,
-			JenkinsMaster.getSlaveRAMMinimumDefault(),
-			JenkinsMaster.getSlavesPerHostDefault());
+			baseInvocationURL, null, invokedBatchSize);
 	}
 
 	public static String getMostAvailableMasterURL(
-		String baseInvocationURL, int invokedBatchSize, int minimumRAM,
-		int maximumSlavesPerHost) {
+		String baseInvocationURL, String blacklist, int invokedBatchSize) {
 
 		return getMostAvailableMasterURL(
-			baseInvocationURL, null, invokedBatchSize, minimumRAM,
-			maximumSlavesPerHost);
+			baseInvocationURL, blacklist, invokedBatchSize, null);
 	}
 
 	public static String getMostAvailableMasterURL(
 		String baseInvocationURL, String blacklist, int invokedBatchSize,
-		int minimumRAM, int maximumSlavesPerHost) {
-
-		return getMostAvailableMasterURL(
-			baseInvocationURL, blacklist, invokedBatchSize, null, minimumRAM,
-			maximumSlavesPerHost);
-	}
-
-	public static String getMostAvailableMasterURL(
-		String baseInvocationURL, String blacklist, int invokedBatchSize,
-		String jobName, int minimumRAM, int maximumSlavesPerHost) {
-
-		return getMostAvailableMasterURL(
-			baseInvocationURL, blacklist, invokedBatchSize, jobName, null,
-			minimumRAM, maximumSlavesPerHost);
-	}
-
-	public static String getMostAvailableMasterURL(
-		String baseInvocationURL, String blacklist, int invokedBatchSize,
-		String jobName, String labelExpression, int minimumRAM,
-		int maximumSlavesPerHost) {
+		String jobName) {
 
 		StringBuilder sb = new StringBuilder();
 
@@ -2992,16 +2964,6 @@ public class JenkinsResultsParserUtil {
 		if (!isNullOrEmpty(jobName)) {
 			sb.append("&jobName=");
 			sb.append(fixURL(jobName));
-		}
-
-		if (!isNullOrEmpty(labelExpression)) {
-			sb.append("&labelExpression=");
-			sb.append(fixURL(labelExpression));
-		}
-
-		if (minimumRAM > 0) {
-			sb.append("&minimumRAM=");
-			sb.append(minimumRAM);
 		}
 
 		try {
@@ -3025,8 +2987,7 @@ public class JenkinsResultsParserUtil {
 			List<JenkinsMaster> availableJenkinsMasters =
 				LoadBalancerUtil.getAvailableJenkinsMasters(
 					LoadBalancerUtil.getMasterPrefix(baseInvocationURL),
-					blacklist, false, jobName, minimumRAM, maximumSlavesPerHost,
-					buildProperties, true);
+					blacklist, buildProperties, true);
 
 			Random random = new Random(getCurrentTimeMillis());
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -2986,8 +2986,9 @@ public class JenkinsResultsParserUtil {
 
 			List<JenkinsMaster> availableJenkinsMasters =
 				LoadBalancerUtil.getAvailableJenkinsMasters(
+					blacklist,
 					LoadBalancerUtil.getMasterPrefix(baseInvocationURL),
-					blacklist, buildProperties, true);
+					buildProperties, true);
 
 			Random random = new Random(getCurrentTimeMillis());
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
@@ -109,17 +109,12 @@ public class LoadBalancerUtil {
 		JenkinsMaster selectedJenkinsMaster = eligibleJenkinsMasters.get(index);
 
 		if (verbose) {
-			StringBuilder sb = new StringBuilder();
-
-			sb.append("Selected master ");
-			sb.append(selectedJenkinsMaster.getName());
-			sb.append(" via round-robin (");
-			sb.append(eligibleJenkinsMasters.size());
-			sb.append(" eligible masters under prefix ");
-			sb.append(masterPrefix);
-			sb.append(")");
-
-			System.out.println(sb.toString());
+			System.out.println(
+				JenkinsResultsParserUtil.combine(
+					"Selected master ", selectedJenkinsMaster.getName(),
+					" via round-robin (",
+					String.valueOf(eligibleJenkinsMasters.size()),
+					" eligible masters under prefix ", masterPrefix, ")"));
 		}
 
 		return "http://" + selectedJenkinsMaster.getName();
@@ -186,20 +181,20 @@ public class LoadBalancerUtil {
 
 		List<String> blacklist = new ArrayList<>();
 
-		String propertyBlacklistString = properties.getProperty(
-			"jenkins.load.balancer.blacklist", "");
+		String propertyBlacklistString = JenkinsResultsParserUtil.getProperty(
+			properties, "jenkins.load.balancer.blacklist");
 
-		for (String blacklistItem : propertyBlacklistString.split(",")) {
-			blacklistItem = blacklistItem.trim();
+		if (propertyBlacklistString != null) {
+			for (String blacklistItem : propertyBlacklistString.split(",")) {
+				blacklistItem = blacklistItem.trim();
 
-			if (!blacklistItem.isEmpty()) {
-				blacklist.add(blacklistItem);
+				if (!blacklistItem.isEmpty()) {
+					blacklist.add(blacklistItem);
+				}
 			}
 		}
 
-		if ((requestBlacklistString != null) &&
-			!requestBlacklistString.isEmpty()) {
-
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(requestBlacklistString)) {
 			String[] requestBlacklistItems = requestBlacklistString.toLowerCase(
 			).split(
 				"\\s*,\\s*"

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
@@ -8,17 +8,11 @@ package com.liferay.jenkins.results.parser;
 import java.io.StringReader;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Random;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -28,118 +22,48 @@ import java.util.regex.Pattern;
 public class LoadBalancerUtil {
 
 	public static List<JenkinsMaster> getAvailableJenkinsMasters(
-		String masterPrefix, String blacklistString, boolean goodClockRequired,
-		int minimumRAM, int maximumSlavesPerHost, Properties properties) {
+		String masterPrefix, String blacklistString, Properties properties) {
 
 		return getAvailableJenkinsMasters(
-			masterPrefix, blacklistString, goodClockRequired, minimumRAM,
-			maximumSlavesPerHost, properties, true);
+			masterPrefix, blacklistString, properties, true);
 	}
 
 	public static List<JenkinsMaster> getAvailableJenkinsMasters(
-		String masterPrefix, String blacklistString, boolean goodClockRequired,
-		int minimumRAM, int maximumSlavesPerHost, Properties properties,
+		String masterPrefix, String blacklistString, Properties properties,
 		boolean verbose) {
 
-		return getAvailableJenkinsMasters(
-			masterPrefix, blacklistString, goodClockRequired, null, minimumRAM,
-			maximumSlavesPerHost, properties, verbose);
-	}
+		List<JenkinsMaster> allJenkinsMasters =
+			_jenkinsMastersMap.computeIfAbsent(
+				masterPrefix,
+				key -> JenkinsResultsParserUtil.getJenkinsMasters(
+					properties, JenkinsMaster.getSlaveRAMMinimumDefault(),
+					JenkinsMaster.getSlavesPerHostDefault(), key));
 
-	public static List<JenkinsMaster> getAvailableJenkinsMasters(
-		String masterPrefix, String blacklistString, boolean goodClockRequired,
-		String jobName, int minimumRAM, int maximumSlavesPerHost,
-		Properties properties, boolean verbose) {
+		List<String> blacklist = _getBlacklist(
+			properties, blacklistString, verbose);
 
-		return getAvailableJenkinsMasters(
-			masterPrefix, blacklistString, goodClockRequired, jobName, null,
-			minimumRAM, maximumSlavesPerHost, properties, verbose);
-	}
-
-	public static List<JenkinsMaster> getAvailableJenkinsMasters(
-		String masterPrefix, String blacklistString, boolean goodClockRequired,
-		String jobName, String labelExpression, int minimumRAM,
-		int maximumSlavesPerHost, Properties properties, boolean verbose) {
-
-		List<JenkinsMaster> allJenkinsMasters = null;
-
-		if (!_jenkinsMasters.containsKey(masterPrefix)) {
-			allJenkinsMasters = JenkinsResultsParserUtil.getJenkinsMasters(
-				properties, JenkinsMaster.getSlaveRAMMinimumDefault(),
-				JenkinsMaster.getSlavesPerHostDefault(), masterPrefix);
-
-			_jenkinsMasters.put(masterPrefix, allJenkinsMasters);
-		}
-		else {
-			allJenkinsMasters = _jenkinsMasters.get(masterPrefix);
-		}
-
-		List<JenkinsMaster> availableJenkinsMasters = new ArrayList<>(
+		List<JenkinsMaster> eligibleJenkinsMasters = new ArrayList<>(
 			allJenkinsMasters.size());
 
-		List<String> blacklist = _getBlacklist(properties, verbose);
-
-		if ((blacklistString != null) && !blacklistString.isEmpty()) {
-			blacklistString = blacklistString.toLowerCase();
-
-			for (String blacklistItem : blacklistString.split("\\s*,\\s*")) {
-				if (!blacklist.contains(blacklistItem)) {
-					blacklist.add(blacklistItem);
-				}
-			}
-		}
-
-		List<String> goodClockList = _getGoodClockList(properties, verbose);
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(labelExpression)) {
-			labelExpression = JenkinsResultsParserUtil.getProperty(
-				properties, "jenkins.osb.jenkins.web.slave.label.minimum.ram",
-				String.valueOf(minimumRAM));
-		}
-
-		List<String> whitelist = _getWhitelist(jobName, properties, verbose);
-
 		for (JenkinsMaster jenkinsMaster : allJenkinsMasters) {
-			if (blacklist.contains(jenkinsMaster.getName()) ||
-				(goodClockRequired &&
-				 !goodClockList.contains(jenkinsMaster.getName())) ||
-				!jenkinsMaster.matchesLabelExpression(labelExpression) ||
-				(jenkinsMaster.getSlaveRAM() < minimumRAM) ||
-				(jenkinsMaster.getSlavesPerHost() > maximumSlavesPerHost) ||
-				(!whitelist.isEmpty() &&
-				 !whitelist.contains(jenkinsMaster.getName()))) {
-
+			if (blacklist.contains(jenkinsMaster.getName())) {
 				continue;
 			}
 
-			availableJenkinsMasters.add(jenkinsMaster);
+			eligibleJenkinsMasters.add(jenkinsMaster);
 		}
 
-		return availableJenkinsMasters;
+		return eligibleJenkinsMasters;
 	}
 
-	public static List<JenkinsMaster> getAvailableJenkinsMasters(
-		String masterPrefix, String blacklistString, int minimumRAM,
-		int maximumSlavesPerHost, Properties properties) {
+	public static String getMasterPrefix(String baseInvocationURL) {
+		Matcher matcher = _urlPattern.matcher(baseInvocationURL);
 
-		return getAvailableJenkinsMasters(
-			masterPrefix, blacklistString, false, minimumRAM,
-			maximumSlavesPerHost, properties, true);
-	}
+		if (!matcher.find()) {
+			return baseInvocationURL;
+		}
 
-	public static List<JenkinsMaster> getAvailableJenkinsMasters(
-		String masterPrefix, String blacklistString, int minimumRAM,
-		int maximumSlavesPerHost, Properties properties, boolean verbose) {
-
-		return getAvailableJenkinsMasters(
-			masterPrefix, blacklistString, false, minimumRAM,
-			maximumSlavesPerHost, properties, true);
-	}
-
-	public static String getMostAvailableMasterURL(
-		boolean clock, Properties properties) {
-
-		return getMostAvailableMasterURL(properties, clock, true);
+		return matcher.group("masterPrefix");
 	}
 
 	public static String getMostAvailableMasterURL(
@@ -151,194 +75,61 @@ public class LoadBalancerUtil {
 	}
 
 	public static String getMostAvailableMasterURL(Properties properties) {
-		return getMostAvailableMasterURL(properties, false, true);
+		return getMostAvailableMasterURL(properties, true);
 	}
 
 	public static String getMostAvailableMasterURL(
 		Properties properties, boolean verbose) {
 
-		return getMostAvailableMasterURL(properties, false, verbose);
-	}
+		String baseInvocationURL = JenkinsResultsParserUtil.getProperty(
+			properties, "base.invocation.url");
 
-	public static String getMostAvailableMasterURL(
-		Properties properties, boolean clock, boolean verbose) {
+		String masterPrefix = getMasterPrefix(baseInvocationURL);
 
-		long start = JenkinsResultsParserUtil.getCurrentTimeMillis();
-
-		int retries = 0;
-
-		while (true) {
-			try {
-				String baseInvocationURL = JenkinsResultsParserUtil.getProperty(
-					properties, "base.invocation.url");
-
-				String masterPrefix = getMasterPrefix(baseInvocationURL);
-
-				if (masterPrefix.equals(baseInvocationURL)) {
-					return baseInvocationURL;
-				}
-
-				String blacklistString = JenkinsResultsParserUtil.getProperty(
-					properties, "blacklist");
-				String jobName = JenkinsResultsParserUtil.getProperty(
-					properties, "job.name");
-
-				Integer minimumRAM = JenkinsMaster.getSlaveRAMMinimumDefault();
-
-				String minimumRAMString = JenkinsResultsParserUtil.getProperty(
-					properties, "minimum.ram");
-
-				if ((minimumRAMString != null) &&
-					minimumRAMString.matches("\\d+")) {
-
-					minimumRAM = Integer.valueOf(minimumRAMString);
-				}
-
-				String labelExpression = JenkinsResultsParserUtil.getProperty(
-					properties, "label.expression");
-
-				if (JenkinsResultsParserUtil.isNullOrEmpty(labelExpression)) {
-					labelExpression = JenkinsResultsParserUtil.getProperty(
-						properties,
-						"jenkins.osb.jenkins.web.slave.label.minimum.ram",
-						String.valueOf(minimumRAM));
-				}
-
-				Integer maximumSlavesPerHost =
-					JenkinsMaster.getSlavesPerHostDefault();
-
-				String maximumSlavesPerHostString =
-					JenkinsResultsParserUtil.getProperty(
-						properties, "maximum.slaves.per.host");
-
-				if ((maximumSlavesPerHostString != null) &&
-					maximumSlavesPerHostString.matches("\\d+")) {
-
-					maximumSlavesPerHost = Integer.valueOf(
-						maximumSlavesPerHost);
-				}
-
-				List<JenkinsMaster> jenkinsMasters = getAvailableJenkinsMasters(
-					masterPrefix, blacklistString, clock, jobName, minimumRAM,
-					maximumSlavesPerHost, properties, verbose);
-
-				long nextUpdateTimestamp = _getNextUpdateTimestamp(
-					masterPrefix);
-
-				if (nextUpdateTimestamp <
-						JenkinsResultsParserUtil.getCurrentTimeMillis()) {
-
-					_updateJenkinsMasters(jenkinsMasters);
-
-					_setNextUpdateTimestamp(
-						masterPrefix,
-						JenkinsResultsParserUtil.getCurrentTimeMillis() +
-							_updateInterval);
-				}
-
-				if (jenkinsMasters.isEmpty()) {
-					return null;
-				}
-
-				Collections.sort(
-					jenkinsMasters,
-					new JenkinsMasterLabelComparator(labelExpression));
-
-				JenkinsMaster mostAvailableJenkinsMaster = jenkinsMasters.get(
-					0);
-
-				if (verbose) {
-					StringBuilder sb = new StringBuilder();
-
-					for (JenkinsMaster jenkinsMaster : jenkinsMasters) {
-						sb.append(jenkinsMaster.getName());
-
-						if (!JenkinsResultsParserUtil.isNullOrEmpty(
-								labelExpression)) {
-
-							sb.append(" [label_expression: ");
-							sb.append(labelExpression);
-							sb.append("]");
-						}
-
-						sb.append(" : ");
-						sb.append(
-							jenkinsMaster.getAvailableSlavesCount(
-								labelExpression));
-						sb.append(" : ");
-						sb.append(
-							jenkinsMaster.getAverageQueueLength(
-								labelExpression));
-						sb.append("\n");
-					}
-
-					System.out.println(sb.toString());
-
-					sb = new StringBuilder();
-
-					sb.append("\nMost available master ");
-					sb.append(mostAvailableJenkinsMaster.getName());
-
-					if (!JenkinsResultsParserUtil.isNullOrEmpty(
-							labelExpression)) {
-
-						sb.append(" [label_expression: ");
-						sb.append(labelExpression);
-						sb.append("]");
-					}
-
-					sb.append(" has ");
-					sb.append(
-						mostAvailableJenkinsMaster.getAvailableSlavesCount(
-							labelExpression));
-					sb.append(" available slaves.");
-
-					System.out.println(sb.toString());
-				}
-
-				int invokedBatchSize = 0;
-
-				try {
-					invokedBatchSize = Integer.parseInt(
-						properties.getProperty("invoked.job.batch.size"));
-				}
-				catch (Exception exception) {
-					invokedBatchSize = 1;
-				}
-
-				mostAvailableJenkinsMaster.addRecentBatch(
-					invokedBatchSize, labelExpression);
-
-				return "http://" + mostAvailableJenkinsMaster.getName();
-			}
-			catch (Exception exception) {
-				if (retries < _RETRIES_SIZE_MAX) {
-					retries++;
-
-					continue;
-				}
-
-				throw exception;
-			}
-			finally {
-				if (verbose) {
-					String durationString =
-						JenkinsResultsParserUtil.toDurationString(
-							JenkinsResultsParserUtil.getCurrentTimeMillis() -
-								start);
-
-					System.out.println(
-						"Got most available master URL in " + durationString);
-				}
-			}
+		if (masterPrefix.equals(baseInvocationURL)) {
+			return baseInvocationURL;
 		}
+
+		String blacklistString = JenkinsResultsParserUtil.getProperty(
+			properties, "blacklist");
+
+		List<JenkinsMaster> eligibleJenkinsMasters = getAvailableJenkinsMasters(
+			masterPrefix, blacklistString, properties, verbose);
+
+		if (eligibleJenkinsMasters.isEmpty()) {
+			return null;
+		}
+
+		AtomicInteger counter = _roundRobinCounters.computeIfAbsent(
+			masterPrefix, key -> new AtomicInteger());
+
+		int index = Math.floorMod(
+			counter.getAndIncrement(), eligibleJenkinsMasters.size());
+
+		JenkinsMaster selectedJenkinsMaster = eligibleJenkinsMasters.get(index);
+
+		if (verbose) {
+			StringBuilder sb = new StringBuilder();
+
+			sb.append("Selected master ");
+			sb.append(selectedJenkinsMaster.getName());
+			sb.append(" via round-robin (");
+			sb.append(eligibleJenkinsMasters.size());
+			sb.append(" eligible masters under prefix ");
+			sb.append(masterPrefix);
+			sb.append(")");
+
+			System.out.println(sb.toString());
+		}
+
+		return "http://" + selectedJenkinsMaster.getName();
 	}
 
 	public static String getMostAvailableMasterURL(
 			String... overridePropertiesArray)
 		throws Exception {
 
-		return getMostAvailableMasterURL(true, overridePropertiesArray);
+		return getMostAvailableMasterURL(null, overridePropertiesArray, true);
 	}
 
 	public static String getMostAvailableMasterURL(
@@ -354,22 +145,14 @@ public class LoadBalancerUtil {
 			boolean verbose)
 		throws Exception {
 
-		return getMostAvailableMasterURL(
-			propertiesURL, overridePropertiesArray, false, verbose);
-	}
-
-	public static String getMostAvailableMasterURL(
-			String propertiesURL, String[] overridePropertiesArray,
-			boolean clock, boolean verbose)
-		throws Exception {
-
-		Properties properties = new Properties();
+		Properties properties;
 
 		if (propertiesURL == null) {
 			properties = JenkinsResultsParserUtil.getBuildProperties(false);
 		}
 		else {
 			properties = new Properties();
+
 			String propertiesString = JenkinsResultsParserUtil.toString(
 				JenkinsResultsParserUtil.getLocalURL(propertiesURL), false,
 				true);
@@ -395,209 +178,51 @@ public class LoadBalancerUtil {
 			}
 		}
 
-		return getMostAvailableMasterURL(properties, clock, verbose);
+		return getMostAvailableMasterURL(properties, verbose);
 	}
 
-	public static void setUpdateInterval(long interval) {
-		_updateInterval = interval;
-	}
+	private static List<String> _getBlacklist(
+		Properties properties, String requestBlacklistString, boolean verbose) {
 
-	public static class JenkinsMasterLabelComparator
-		implements Comparator<JenkinsMaster> {
+		List<String> blacklist = new ArrayList<>();
 
-		public JenkinsMasterLabelComparator(String labelExpression) {
-			_labelExpression = labelExpression;
+		String propertyBlacklistString = properties.getProperty(
+			"jenkins.load.balancer.blacklist", "");
+
+		for (String blacklistItem : propertyBlacklistString.split(",")) {
+			blacklistItem = blacklistItem.trim();
+
+			if (!blacklistItem.isEmpty()) {
+				blacklist.add(blacklistItem);
+			}
 		}
 
-		@Override
-		public int compare(
-			JenkinsMaster jenkinsMaster1, JenkinsMaster jenkinsMaster2) {
+		if ((requestBlacklistString != null) &&
+			!requestBlacklistString.isEmpty()) {
 
-			Integer value = null;
+			String[] requestBlacklistItems = requestBlacklistString.toLowerCase(
+			).split(
+				"\\s*,\\s*"
+			);
 
-			Integer availableSlavesCount1 =
-				jenkinsMaster1.getAvailableSlavesCount(_labelExpression);
-			Integer availableSlavesCount2 =
-				jenkinsMaster2.getAvailableSlavesCount(_labelExpression);
-
-			if ((availableSlavesCount1 > 0) || (availableSlavesCount2 > 0)) {
-				value = availableSlavesCount1.compareTo(availableSlavesCount2);
-			}
-
-			if ((value == null) || (value == 0)) {
-				Float averageQueueLength1 =
-					jenkinsMaster1.getAverageQueueLength(_labelExpression);
-				Float averageQueueLength2 =
-					jenkinsMaster2.getAverageQueueLength(_labelExpression);
-
-				value = -1 * averageQueueLength1.compareTo(averageQueueLength2);
-			}
-
-			if (value != 0) {
-				return -value;
-			}
-
-			Random random = new Random();
-
-			while (true) {
-				int result = random.nextInt(3) - 1;
-
-				if (result != 0) {
-					return result;
+			for (String blacklistItem : requestBlacklistItems) {
+				if (!blacklist.contains(blacklistItem)) {
+					blacklist.add(blacklistItem);
 				}
 			}
 		}
 
-		private final String _labelExpression;
-
-	}
-
-	protected static String getMasterPrefix(String baseInvocationURL) {
-		Matcher matcher = _urlPattern.matcher(baseInvocationURL);
-
-		if (!matcher.find()) {
-			return baseInvocationURL;
-		}
-
-		return matcher.group("masterPrefix");
-	}
-
-	private static List<String> _getBlacklist(
-		Properties properties, boolean verbose) {
-
-		List<String> blacklist = new ArrayList<>();
-
-		String blacklistString = properties.getProperty(
-			"jenkins.load.balancer.blacklist", "");
-
 		if (verbose) {
-			System.out.println("Blacklist: " + blacklistString);
-		}
-
-		for (String blacklistItem : blacklistString.split(",")) {
-			blacklist.add(blacklistItem.trim());
+			System.out.println("Blacklist: " + blacklist);
 		}
 
 		return blacklist;
 	}
 
-	private static List<String> _getGoodClockList(
-		Properties properties, boolean verbose) {
-
-		String goodClockString = properties.getProperty(
-			"jenkins.load.balancer.good.clock.list");
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(goodClockString)) {
-			return Collections.emptyList();
-		}
-
-		goodClockString = goodClockString.trim();
-
-		if (verbose) {
-			System.out.println(
-				"List of good clock masters: " + goodClockString);
-		}
-
-		return Arrays.asList(goodClockString.split("\\s*,\\s*"));
-	}
-
-	private static long _getNextUpdateTimestamp(String masterPrefix) {
-		if (!_nextUpdateTimestampMap.containsKey(masterPrefix)) {
-			return 0;
-		}
-
-		return _nextUpdateTimestampMap.get(masterPrefix);
-	}
-
-	private static List<String> _getWhitelist(
-		String jobName, Properties properties, boolean verbose) {
-
-		List<String> whitelist = new ArrayList<>();
-
-		String whitelistString = JenkinsResultsParserUtil.getProperty(
-			properties, "jenkins.load.balancer.whitelist", jobName);
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(whitelistString)) {
-			return whitelist;
-		}
-
-		whitelistString = JenkinsResultsParserUtil.expandSlaveRange(
-			whitelistString);
-
-		if (verbose) {
-			System.out.println("Whitelist: " + whitelistString);
-		}
-
-		for (String whitelistItem : whitelistString.split(",")) {
-			whitelist.add(whitelistItem.trim());
-		}
-
-		return whitelist;
-	}
-
-	private static void _setNextUpdateTimestamp(
-		String masterPrefix, long nextUpdateTimestamp) {
-
-		_nextUpdateTimestampMap.put(masterPrefix, nextUpdateTimestamp);
-	}
-
-	private static void _updateJenkinsMasters(
-		List<JenkinsMaster> jenkinsMasters) {
-
-		if (jenkinsMasters.isEmpty()) {
-			return;
-		}
-
-		ExecutorService executorService = Executors.newFixedThreadPool(
-			jenkinsMasters.size());
-
-		for (final JenkinsMaster jenkinsMaster : jenkinsMasters) {
-			executorService.execute(
-				new Runnable() {
-
-					@Override
-					public void run() {
-						jenkinsMaster.update();
-					}
-
-				});
-		}
-
-		executorService.shutdown();
-
-		try {
-			executorService.awaitTermination(10, TimeUnit.SECONDS);
-		}
-		catch (InterruptedException interruptedException) {
-			throw new RuntimeException(interruptedException);
-		}
-
-		synchronized (_urlPattern) {
-			List<JenkinsMaster> unavailableJenkinsMasters = new ArrayList<>(
-				jenkinsMasters.size());
-
-			for (JenkinsMaster jenkinsMaster : jenkinsMasters) {
-				if (!jenkinsMaster.isAvailable()) {
-					unavailableJenkinsMasters.add(jenkinsMaster);
-				}
-			}
-
-			jenkinsMasters.removeAll(unavailableJenkinsMasters);
-
-			if (jenkinsMasters.isEmpty()) {
-				throw new RuntimeException(
-					"Unable to communicate with any Jenkins masters");
-			}
-		}
-	}
-
-	private static final int _RETRIES_SIZE_MAX = 3;
-
-	private static final Map<String, List<JenkinsMaster>> _jenkinsMasters =
-		new HashMap<>();
-	private static final Map<String, Long> _nextUpdateTimestampMap =
-		new HashMap<>();
-	private static long _updateInterval = 1000 * 10;
+	private static final Map<String, List<JenkinsMaster>> _jenkinsMastersMap =
+		new ConcurrentHashMap<>();
+	private static final Map<String, AtomicInteger> _roundRobinCounters =
+		new ConcurrentHashMap<>();
 	private static final Pattern _urlPattern = Pattern.compile(
 		"http://(?<masterPrefix>.+-\\d?).liferay.com");
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
@@ -101,7 +102,7 @@ public class LoadBalancerUtil {
 		}
 
 		AtomicInteger counter = _roundRobinCounters.computeIfAbsent(
-			masterPrefix, key -> new AtomicInteger());
+			masterPrefix, key -> new AtomicInteger(_random.nextInt()));
 
 		int index = Math.floorMod(
 			counter.getAndIncrement(), eligibleJenkinsMasters.size());
@@ -216,6 +217,7 @@ public class LoadBalancerUtil {
 
 	private static final Map<String, List<JenkinsMaster>> _jenkinsMastersMap =
 		new ConcurrentHashMap<>();
+	private static final Random _random = new Random();
 	private static final Map<String, AtomicInteger> _roundRobinCounters =
 		new ConcurrentHashMap<>();
 	private static final Pattern _urlPattern = Pattern.compile(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
@@ -23,14 +23,14 @@ import java.util.regex.Pattern;
 public class LoadBalancerUtil {
 
 	public static List<JenkinsMaster> getAvailableJenkinsMasters(
-		String masterPrefix, String blacklistString, Properties properties) {
+		String blacklistString, String masterPrefix, Properties properties) {
 
 		return getAvailableJenkinsMasters(
-			masterPrefix, blacklistString, properties, true);
+			blacklistString, masterPrefix, properties, true);
 	}
 
 	public static List<JenkinsMaster> getAvailableJenkinsMasters(
-		String masterPrefix, String blacklistString, Properties properties,
+		String blacklistString, String masterPrefix, Properties properties,
 		boolean verbose) {
 
 		List<JenkinsMaster> allJenkinsMasters =
@@ -95,7 +95,7 @@ public class LoadBalancerUtil {
 			properties, "blacklist");
 
 		List<JenkinsMaster> eligibleJenkinsMasters = getAvailableJenkinsMasters(
-			masterPrefix, blacklistString, properties, verbose);
+			blacklistString, masterPrefix, properties, verbose);
 
 		if (eligibleJenkinsMasters.isEmpty()) {
 			return null;
@@ -196,10 +196,11 @@ public class LoadBalancerUtil {
 		}
 
 		if (!JenkinsResultsParserUtil.isNullOrEmpty(requestBlacklistString)) {
-			String[] requestBlacklistItems = requestBlacklistString.toLowerCase(
-			).split(
-				"\\s*,\\s*"
-			);
+			String lowerCaseRequestBlacklistString =
+				requestBlacklistString.toLowerCase();
+
+			String[] requestBlacklistItems =
+				lowerCaseRequestBlacklistString.split("\\s*,\\s*");
 
 			for (String blacklistItem : requestBlacklistItems) {
 				if (!blacklist.contains(blacklistItem)) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/QAWebsitesControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/QAWebsitesControllerBuildRunner.java
@@ -89,10 +89,7 @@ public class QAWebsitesControllerBuildRunner
 
 			String mostAvailableMasterURL =
 				JenkinsResultsParserUtil.getMostAvailableMasterURL(
-					"http://" + cohortName + ".liferay.com", null, 1,
-					getLabelExpression(jobName), jobName,
-					JenkinsMaster.getSlaveRAMMinimumDefault(),
-					JenkinsMaster.getSlavesPerHostDefault());
+					"http://" + cohortName + ".liferay.com", null, 1, jobName);
 
 			invocationMasterHostname = mostAvailableMasterURL.replaceAll(
 				"https?://([^\\.]+)(.liferay.com.*)?", "\1");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestResultsConsistencyReportControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestResultsConsistencyReportControllerBuildRunner.java
@@ -71,9 +71,7 @@ public class TestResultsConsistencyReportControllerBuildRunner
 		return JenkinsResultsParserUtil.combine(
 			JenkinsResultsParserUtil.getMostAvailableMasterURL(
 				"http://" + getInvocationCohortName() + ".liferay.com", null, 1,
-				jobName, getLabelExpression(jobName),
-				JenkinsMaster.getSlaveRAMMinimumDefault(),
-				JenkinsMaster.getSlavesPerHostDefault()),
+				jobName),
 			"/job/", jobName);
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuildRunner.java
@@ -124,9 +124,7 @@ public abstract class TopLevelBuildRunner<T extends TopLevelBuildData>
 		}
 
 		return JenkinsResultsParserUtil.getMostAvailableMasterURL(
-			"http://" + cohortName + ".liferay.com", null, 1, jobName,
-			getLabelExpression(jobName), getSlaveRAMMinimum(),
-			JenkinsMaster.getSlavesPerHostDefault());
+			"http://" + cohortName + ".liferay.com", null, 1, jobName);
 	}
 
 	protected String getBuildParameter(String key) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuildRunner.java
@@ -144,11 +144,6 @@ public abstract class TopLevelBuildRunner<T extends TopLevelBuildData>
 		return jobProperty.getValue();
 	}
 
-	@Override
-	protected int getSlaveRAMMinimum() {
-		return 24;
-	}
-
 	protected TopLevelBuild getTopLevelBuild() {
 		return _topLevelBuild;
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/github/webhook/GitHubWebhookPayloadProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/github/webhook/GitHubWebhookPayloadProcessor.java
@@ -8,7 +8,6 @@ package com.liferay.jenkins.results.parser.github.webhook;
 import com.liferay.jenkins.results.parser.GitCommit;
 import com.liferay.jenkins.results.parser.GitHubRemoteGitCommit;
 import com.liferay.jenkins.results.parser.GitHubRemoteGitRepository;
-import com.liferay.jenkins.results.parser.JenkinsMaster;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HttpRequestMethod;
 import com.liferay.jenkins.results.parser.JenkinsStopBuildUtil;
@@ -1629,8 +1628,7 @@ public class GitHubWebhookPayloadProcessor {
 				"http://test-1.liferay.com",
 				_jenkinsBuildProperties.getProperty(
 					"jenkins.load.balancer.blacklist", ""),
-				1, JenkinsMaster.getSlaveRAMMinimumDefault(),
-				JenkinsMaster.getSlavesPerHostDefault());
+				1);
 		}
 		catch (Exception exception) {
 			if (_log.isInfoEnabled()) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BaseBundlePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BaseBundlePersistentResource.java
@@ -204,7 +204,7 @@ public abstract class BaseBundlePersistentResource
 
 		JenkinsMaster producerJenkinsMaster =
 			JenkinsResultsParserUtil.getMostAvailableJenkinsMaster(
-				_getBaseInvocationURL(), 1, _SLAVE_LABEL);
+				_getBaseInvocationURL(), 1);
 
 		long producerQueueId = JenkinsResultsParserUtil.invokeJenkinsBuild(
 			producerJenkinsMaster, _JOB_NAME, buildParameters);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7532

**What is being fixed:** The existing LoadBalancer was built for the legacy data-center CI environment where Jenkins slave nodes were static. Now that all CI runs in AWS with dynamic/ephemeral slaves of uniform shape, the static-slave assumptions (available-slave counts, average queue length, good-clock list, label-expression filter, minimum RAM, maximum slaves per host, per-master availability probing) are throwing off the load calculation. The blacklist machinery has also lost most of its original purpose since the excluded job categories are no longer in rotation, but exclusion-at-dispatch-time still needs to be honored.

**How it is being fixed:** The load-calculation logic in `LoadBalancerUtil` is replaced with simple round-robin selection -- a static `AtomicInteger` counter per master prefix, seeded with a random offset so independent JVMs don't all start on the same master, indexed via `Math.floorMod` into the eligible pool. The property blacklist (`jenkins.load.balancer.blacklist`) and per-request blacklist string are both still honored at dispatch time. The simplified-away parameters (`minimumRAM`, `maximumSlavesPerHost`, `labelExpression`) are stripped from `getMostAvailableMasterURL` / `getMostAvailableJenkinsMaster` / `JenkinsCohort.getMostAvailableJenkinsMaster`, and the dead `getLabelExpression` / `getSlaveRAMMinimum` helpers are removed from the BuildRunners and `DefaultBuildUpdater`. The webhook's counter isolation is achieved by process boundary -- the webhook and the load-balancer servlet run in separate JVMs, each with its own static counter map -- so no separate instance or scope key is needed. Round-robin cycling, blacklist exclusion (property + per-request), and the all-blacklisted edge case are covered by `LoadBalancerTest`, and the change was validated end-to-end on a sandbox `osb-jenkins-web` + `osb-github-web` deployment.