### PR TITLE
LRCI-7500 Redispatch bundle-builder on cached FAILURE in follower path

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BaseBundlePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BaseBundlePersistentResource.java
@@ -180,7 +180,7 @@ public abstract class BaseBundlePersistentResource
 	}
 
 	protected void start() {
-		_dispatch();
+		_invokeBuild();
 
 		print("Start building bundles at " + _getProducerJobURL());
 	}
@@ -238,7 +238,7 @@ public abstract class BaseBundlePersistentResource
 
 			if (getStatus() == Status.FAILED) {
 				if (_redispatchAttempts < _MAX_REDISPATCH_ATTEMPTS) {
-					_attemptRedispatch(dataJSONObject);
+					_redispatchBuild(dataJSONObject);
 				}
 				else {
 					print("No redispatch attempts remaining");
@@ -342,98 +342,39 @@ public abstract class BaseBundlePersistentResource
 		}
 	}
 
-	private void _attemptRedispatch(JSONObject cachedDataJSONObject) {
-		JSONObject historyEntryJSONObject = new JSONObject();
-
-		historyEntryJSONObject.put(
-			"controller_build_url",
-			cachedDataJSONObject.optString("controller_build_url")
-		).put(
-			"producer_build_url",
-			cachedDataJSONObject.optString("producer_build_url")
-		).put(
-			"status", cachedDataJSONObject.optString("status")
-		);
-
-		_redispatchHistoryJSONArray.put(historyEntryJSONObject);
-
-		while (_redispatchHistoryJSONArray.length() >
-					_MAX_REDISPATCH_ATTEMPTS) {
-
-			_redispatchHistoryJSONArray.remove(0);
-		}
-
-		_redispatchAttempts++;
-
-		String currentTopLevelBuildURL = getCurrentTopLevelBuildURL();
-
-		setControllerBuildURL(currentTopLevelBuildURL);
-
-		setProducerBuildURL(null);
-		setProducerJenkinsMaster(null);
-		setProducerQueueId(0);
-		setStatus(Status.IN_QUEUE);
-
-		save();
-
-		JenkinsResultsParserUtil.sleep(_STAMPEDE_CLAIM_VERIFY_TIME);
-
-		JSONObject verifyDataJSONObject = getDataJSONObject();
-
-		if (verifyDataJSONObject != null) {
-			String winningControllerBuildURL = verifyDataJSONObject.optString(
-				"controller_build_url");
-
-			if (!Objects.equals(
-					currentTopLevelBuildURL, winningControllerBuildURL)) {
-
-				print(
-					"Following redispatched bundles at " +
-						winningControllerBuildURL);
-
-				setControllerBuildURL(winningControllerBuildURL);
-				setProducerBuildURL(
-					verifyDataJSONObject.optString("producer_build_url"));
-				setProducerJenkinsMaster(null);
-
-				String producerJenkinsMasterName =
-					verifyDataJSONObject.optString("producer_jenkins_master");
-
-				if (!JenkinsResultsParserUtil.isNullOrEmpty(
-						producerJenkinsMasterName)) {
-
-					setProducerJenkinsMaster(
-						JenkinsMaster.getInstance(producerJenkinsMasterName));
-				}
-
-				setProducerQueueId(
-					verifyDataJSONObject.optLong("producer_queue_id"));
-				setStatus(
-					Status.valueOf(verifyDataJSONObject.getString("status")));
-
-				_redispatchAttempts = verifyDataJSONObject.optInt(
-					"redispatch_attempts", _redispatchAttempts);
-
-				JSONArray winnerRedispatchHistoryJSONArray =
-					verifyDataJSONObject.optJSONArray("redispatch_history");
-
-				if (winnerRedispatchHistoryJSONArray != null) {
-					_redispatchHistoryJSONArray =
-						winnerRedispatchHistoryJSONArray;
-				}
-
-				return;
-			}
-		}
-
-		_dispatch();
-
-		print(
-			"Redispatching bundles (" + _redispatchAttempts + " of " +
-				_MAX_REDISPATCH_ATTEMPTS + ") at " + _getProducerJobURL());
+	private String _getAxisVariable() {
+		return String.valueOf(getType());
 	}
 
-	private void _dispatch() {
+	private String _getBaseInvocationURL() {
+		try {
+			String serverType = "production";
+
+			String topLevelBuildURL = getCurrentTopLevelBuildURL();
+
+			if (topLevelBuildURL.contains("test-5")) {
+				serverType = "staging";
+			}
+
+			return JenkinsResultsParserUtil.getBuildProperty(
+				"github.webhook.base.invocation.url", serverType);
+		}
+		catch (IOException ioException) {
+			return _BASE_INVOCATION_URL;
+		}
+	}
+
+	private String _getProducerJobURL() {
+		JenkinsMaster producerJenkinsMaster = getProducerJenkinsMaster();
+
+		if (producerJenkinsMaster == null) {
+			return null;
+		}
+
+		return producerJenkinsMaster.getRemoteURL() + "job/" + _JOB_NAME;
+	}
+
+	private void _invokeBuild() {
 		StringBuilder sb = new StringBuilder();
 
 		sb.append(_JOB_VARIANT);
@@ -483,36 +424,95 @@ public abstract class BaseBundlePersistentResource
 		save();
 	}
 
-	private String _getAxisVariable() {
-		return String.valueOf(getType());
-	}
+	private void _redispatchBuild(JSONObject cachedDataJSONObject) {
+		JSONObject historyEntryJSONObject = new JSONObject();
 
-	private String _getBaseInvocationURL() {
-		try {
-			String serverType = "production";
+		historyEntryJSONObject.put(
+			"controller_build_url",
+			cachedDataJSONObject.optString("controller_build_url")
+		).put(
+			"producer_build_url",
+			cachedDataJSONObject.optString("producer_build_url")
+		).put(
+			"status", cachedDataJSONObject.optString("status")
+		);
 
-			String topLevelBuildURL = getCurrentTopLevelBuildURL();
+		_redispatchHistoryJSONArray.put(historyEntryJSONObject);
 
-			if (topLevelBuildURL.contains("test-5")) {
-				serverType = "staging";
+		while (_redispatchHistoryJSONArray.length() >
+					_MAX_REDISPATCH_ATTEMPTS) {
+
+			_redispatchHistoryJSONArray.remove(0);
+		}
+
+		_redispatchAttempts++;
+
+		String currentTopLevelBuildURL = getCurrentTopLevelBuildURL();
+
+		setControllerBuildURL(currentTopLevelBuildURL);
+
+		setProducerBuildURL(null);
+		setProducerJenkinsMaster(null);
+		setProducerQueueId(0);
+		setStatus(Status.IN_QUEUE);
+
+		save();
+
+		JenkinsResultsParserUtil.sleep(_REDISPATCH_VERIFY_TIME);
+
+		JSONObject verifyDataJSONObject = getDataJSONObject();
+
+		if (verifyDataJSONObject != null) {
+			String winningControllerBuildURL = verifyDataJSONObject.optString(
+				"controller_build_url");
+
+			if (!Objects.equals(
+					currentTopLevelBuildURL, winningControllerBuildURL)) {
+
+				print(
+					"Following redispatched bundles at " +
+						winningControllerBuildURL);
+
+				setControllerBuildURL(winningControllerBuildURL);
+				setProducerBuildURL(
+					verifyDataJSONObject.optString("producer_build_url"));
+				setProducerJenkinsMaster(null);
+
+				String producerJenkinsMasterName =
+					verifyDataJSONObject.optString("producer_jenkins_master");
+
+				if (!JenkinsResultsParserUtil.isNullOrEmpty(
+						producerJenkinsMasterName)) {
+
+					setProducerJenkinsMaster(
+						JenkinsMaster.getInstance(producerJenkinsMasterName));
+				}
+
+				setProducerQueueId(
+					verifyDataJSONObject.optLong("producer_queue_id"));
+				setStatus(
+					Status.valueOf(verifyDataJSONObject.getString("status")));
+
+				_redispatchAttempts = verifyDataJSONObject.optInt(
+					"redispatch_attempts", _redispatchAttempts);
+
+				JSONArray winnerRedispatchHistoryJSONArray =
+					verifyDataJSONObject.optJSONArray("redispatch_history");
+
+				if (winnerRedispatchHistoryJSONArray != null) {
+					_redispatchHistoryJSONArray =
+						winnerRedispatchHistoryJSONArray;
+				}
+
+				return;
 			}
-
-			return JenkinsResultsParserUtil.getBuildProperty(
-				"github.webhook.base.invocation.url", serverType);
-		}
-		catch (IOException ioException) {
-			return _BASE_INVOCATION_URL;
-		}
-	}
-
-	private String _getProducerJobURL() {
-		JenkinsMaster producerJenkinsMaster = getProducerJenkinsMaster();
-
-		if (producerJenkinsMaster == null) {
-			return null;
 		}
 
-		return producerJenkinsMaster.getRemoteURL() + "job/" + _JOB_NAME;
+		_invokeBuild();
+
+		print(
+			"Redispatching bundles (" + _redispatchAttempts + " of " +
+				_MAX_REDISPATCH_ATTEMPTS + ") at " + _getProducerJobURL());
 	}
 
 	private void _updateBuild(String producerBuildURL) {
@@ -565,7 +565,7 @@ public abstract class BaseBundlePersistentResource
 
 	private static final int _MAX_REDISPATCH_ATTEMPTS = 1;
 
-	private static final long _STAMPEDE_CLAIM_VERIFY_TIME = 1000 * 10;
+	private static final long _REDISPATCH_VERIFY_TIME = 1000 * 10;
 
 	private Build _build;
 	private int _failCount;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BaseBundlePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BaseBundlePersistentResource.java
@@ -382,9 +382,9 @@ public abstract class BaseBundlePersistentResource
 
 		String key = sb.toString();
 
-		Properties startProperties = getStartProperties();
-
 		BuildDatabase buildDatabase = getBuildDatabase();
+
+		Properties startProperties = getStartProperties();
 
 		buildDatabase.putProperties(key, startProperties, true);
 
@@ -460,26 +460,23 @@ public abstract class BaseBundlePersistentResource
 
 		JenkinsResultsParserUtil.sleep(_REDISPATCH_VERIFY_TIME);
 
-		JSONObject verifyDataJSONObject = getDataJSONObject();
+		JSONObject dataJSONObject = getDataJSONObject();
 
-		if (verifyDataJSONObject != null) {
-			String winningControllerBuildURL = verifyDataJSONObject.optString(
+		if (dataJSONObject != null) {
+			String controllerBuildURL = dataJSONObject.optString(
 				"controller_build_url");
 
-			if (!Objects.equals(
-					currentTopLevelBuildURL, winningControllerBuildURL)) {
-
+			if (!Objects.equals(currentTopLevelBuildURL, controllerBuildURL)) {
 				print(
-					"Following redispatched bundles at " +
-						winningControllerBuildURL);
+					"Following redispatched bundles at " + controllerBuildURL);
 
-				setControllerBuildURL(winningControllerBuildURL);
+				setControllerBuildURL(controllerBuildURL);
 				setProducerBuildURL(
-					verifyDataJSONObject.optString("producer_build_url"));
+					dataJSONObject.optString("producer_build_url"));
 				setProducerJenkinsMaster(null);
 
-				String producerJenkinsMasterName =
-					verifyDataJSONObject.optString("producer_jenkins_master");
+				String producerJenkinsMasterName = dataJSONObject.optString(
+					"producer_jenkins_master");
 
 				if (!JenkinsResultsParserUtil.isNullOrEmpty(
 						producerJenkinsMasterName)) {
@@ -488,20 +485,17 @@ public abstract class BaseBundlePersistentResource
 						JenkinsMaster.getInstance(producerJenkinsMasterName));
 				}
 
-				setProducerQueueId(
-					verifyDataJSONObject.optLong("producer_queue_id"));
-				setStatus(
-					Status.valueOf(verifyDataJSONObject.getString("status")));
+				setProducerQueueId(dataJSONObject.optLong("producer_queue_id"));
+				setStatus(Status.valueOf(dataJSONObject.getString("status")));
 
-				_redispatchAttempts = verifyDataJSONObject.optInt(
+				_redispatchAttempts = dataJSONObject.optInt(
 					"redispatch_attempts", _redispatchAttempts);
 
-				JSONArray winnerRedispatchHistoryJSONArray =
-					verifyDataJSONObject.optJSONArray("redispatch_history");
+				JSONArray redispatchHistoryJSONArray =
+					dataJSONObject.optJSONArray("redispatch_history");
 
-				if (winnerRedispatchHistoryJSONArray != null) {
-					_redispatchHistoryJSONArray =
-						winnerRedispatchHistoryJSONArray;
+				if (redispatchHistoryJSONArray != null) {
+					_redispatchHistoryJSONArray = redispatchHistoryJSONArray;
 				}
 
 				return;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BaseBundlePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BaseBundlePersistentResource.java
@@ -511,8 +511,10 @@ public abstract class BaseBundlePersistentResource
 		_invokeBuild();
 
 		print(
-			"Redispatching bundles (" + _redispatchAttempts + " of " +
-				_MAX_REDISPATCH_ATTEMPTS + ") at " + _getProducerJobURL());
+			JenkinsResultsParserUtil.combine(
+				"Redispatching bundles (", String.valueOf(_redispatchAttempts),
+				" of ", String.valueOf(_MAX_REDISPATCH_ATTEMPTS), ") at ",
+				_getProducerJobURL()));
 	}
 
 	private void _updateBuild(String producerBuildURL) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BaseBundlePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BaseBundlePersistentResource.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 /**
@@ -169,54 +170,17 @@ public abstract class BaseBundlePersistentResource
 		return _workspace;
 	}
 
+	@Override
+	protected void populateDataJSONObject(JSONObject dataJSONObject) {
+		dataJSONObject.put(
+			"redispatch_attempts", _redispatchAttempts
+		).put(
+			"redispatch_history", _redispatchHistoryJSONArray
+		);
+	}
+
 	protected void start() {
-		StringBuilder sb = new StringBuilder();
-
-		sb.append(_JOB_VARIANT);
-		sb.append("/start.properties");
-
-		String key = sb.toString();
-
-		Properties startProperties = getStartProperties();
-
-		BuildDatabase buildDatabase = getBuildDatabase();
-
-		buildDatabase.putProperties(key, startProperties, true);
-
-		buildDatabase.uploadBuildDatabaseFileToCloudBucket();
-
-		Map<String, String> buildParameters = new HashMap<>();
-
-		for (String startPropertyName : startProperties.stringPropertyNames()) {
-			String startPropertyValue = JenkinsResultsParserUtil.getProperty(
-				startProperties, startPropertyName);
-
-			if (JenkinsResultsParserUtil.isNullOrEmpty(startPropertyValue)) {
-				continue;
-			}
-
-			buildParameters.put(startPropertyName, startPropertyValue);
-		}
-
-		buildParameters.put("AXIS_VARIABLE", _getAxisVariable());
-		buildParameters.put("BUILD_PRIORITY", _BUILD_PRIORITY);
-		buildParameters.put("JOB_VARIANT", _JOB_VARIANT);
-		buildParameters.put("SLAVE_LABEL", "slave-bundle-builder");
-
-		JenkinsMaster producerJenkinsMaster =
-			JenkinsResultsParserUtil.getMostAvailableJenkinsMaster(
-				_getBaseInvocationURL(), 1);
-
-		long producerQueueId = JenkinsResultsParserUtil.invokeJenkinsBuild(
-			producerJenkinsMaster, _JOB_NAME, buildParameters);
-
-		setControllerBuildURL(getCurrentTopLevelBuildURL());
-		setProducerJenkinsMaster(producerJenkinsMaster);
-		setProducerQueueId(producerQueueId);
-
-		setStatus(Status.IN_QUEUE);
-
-		save();
+		_dispatch();
 
 		print("Start building bundles at " + _getProducerJobURL());
 	}
@@ -258,6 +222,30 @@ public abstract class BaseBundlePersistentResource
 
 			setProducerQueueId(dataJSONObject.optLong("producer_queue_id"));
 			setStatus(Status.valueOf(dataJSONObject.getString("status")));
+
+			_redispatchAttempts = dataJSONObject.optInt(
+				"redispatch_attempts", 0);
+
+			JSONArray redispatchHistoryJSONArray = dataJSONObject.optJSONArray(
+				"redispatch_history");
+
+			if (redispatchHistoryJSONArray != null) {
+				_redispatchHistoryJSONArray = redispatchHistoryJSONArray;
+			}
+			else {
+				_redispatchHistoryJSONArray = new JSONArray();
+			}
+
+			if (getStatus() == Status.FAILED) {
+				if (_redispatchAttempts < _MAX_REDISPATCH_ATTEMPTS) {
+					_attemptRedispatch(dataJSONObject);
+				}
+				else {
+					print("No redispatch attempts remaining");
+				}
+
+				return;
+			}
 
 			if (isMissing()) {
 				_missingCount++;
@@ -354,6 +342,147 @@ public abstract class BaseBundlePersistentResource
 		}
 	}
 
+	private void _attemptRedispatch(JSONObject cachedDataJSONObject) {
+		JSONObject historyEntryJSONObject = new JSONObject();
+
+		historyEntryJSONObject.put(
+			"controller_build_url",
+			cachedDataJSONObject.optString("controller_build_url")
+		).put(
+			"producer_build_url",
+			cachedDataJSONObject.optString("producer_build_url")
+		).put(
+			"status", cachedDataJSONObject.optString("status")
+		);
+
+		_redispatchHistoryJSONArray.put(historyEntryJSONObject);
+
+		while (_redispatchHistoryJSONArray.length() >
+					_MAX_REDISPATCH_ATTEMPTS) {
+
+			_redispatchHistoryJSONArray.remove(0);
+		}
+
+		_redispatchAttempts++;
+
+		String currentTopLevelBuildURL = getCurrentTopLevelBuildURL();
+
+		setControllerBuildURL(currentTopLevelBuildURL);
+
+		setProducerBuildURL(null);
+		setProducerJenkinsMaster(null);
+		setProducerQueueId(0);
+		setStatus(Status.IN_QUEUE);
+
+		save();
+
+		JenkinsResultsParserUtil.sleep(_STAMPEDE_CLAIM_VERIFY_TIME);
+
+		JSONObject verifyDataJSONObject = getDataJSONObject();
+
+		if (verifyDataJSONObject != null) {
+			String winningControllerBuildURL = verifyDataJSONObject.optString(
+				"controller_build_url");
+
+			if (!Objects.equals(
+					currentTopLevelBuildURL, winningControllerBuildURL)) {
+
+				print(
+					"Following redispatched bundles at " +
+						winningControllerBuildURL);
+
+				setControllerBuildURL(winningControllerBuildURL);
+				setProducerBuildURL(
+					verifyDataJSONObject.optString("producer_build_url"));
+				setProducerJenkinsMaster(null);
+
+				String producerJenkinsMasterName =
+					verifyDataJSONObject.optString("producer_jenkins_master");
+
+				if (!JenkinsResultsParserUtil.isNullOrEmpty(
+						producerJenkinsMasterName)) {
+
+					setProducerJenkinsMaster(
+						JenkinsMaster.getInstance(producerJenkinsMasterName));
+				}
+
+				setProducerQueueId(
+					verifyDataJSONObject.optLong("producer_queue_id"));
+				setStatus(
+					Status.valueOf(verifyDataJSONObject.getString("status")));
+
+				_redispatchAttempts = verifyDataJSONObject.optInt(
+					"redispatch_attempts", _redispatchAttempts);
+
+				JSONArray winnerRedispatchHistoryJSONArray =
+					verifyDataJSONObject.optJSONArray("redispatch_history");
+
+				if (winnerRedispatchHistoryJSONArray != null) {
+					_redispatchHistoryJSONArray =
+						winnerRedispatchHistoryJSONArray;
+				}
+
+				return;
+			}
+		}
+
+		_dispatch();
+
+		print(
+			"Redispatching bundles (" + _redispatchAttempts + " of " +
+				_MAX_REDISPATCH_ATTEMPTS + ") at " + _getProducerJobURL());
+	}
+
+	private void _dispatch() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append(_JOB_VARIANT);
+		sb.append("/start.properties");
+
+		String key = sb.toString();
+
+		Properties startProperties = getStartProperties();
+
+		BuildDatabase buildDatabase = getBuildDatabase();
+
+		buildDatabase.putProperties(key, startProperties, true);
+
+		buildDatabase.uploadBuildDatabaseFileToCloudBucket();
+
+		Map<String, String> buildParameters = new HashMap<>();
+
+		for (String startPropertyName : startProperties.stringPropertyNames()) {
+			String startPropertyValue = JenkinsResultsParserUtil.getProperty(
+				startProperties, startPropertyName);
+
+			if (JenkinsResultsParserUtil.isNullOrEmpty(startPropertyValue)) {
+				continue;
+			}
+
+			buildParameters.put(startPropertyName, startPropertyValue);
+		}
+
+		buildParameters.put("AXIS_VARIABLE", _getAxisVariable());
+		buildParameters.put("BUILD_PRIORITY", _BUILD_PRIORITY);
+		buildParameters.put("JOB_VARIANT", _JOB_VARIANT);
+		buildParameters.put("SLAVE_LABEL", "slave-bundle-builder");
+
+		JenkinsMaster producerJenkinsMaster =
+			JenkinsResultsParserUtil.getMostAvailableJenkinsMaster(
+				_getBaseInvocationURL(), 1);
+
+		long producerQueueId = JenkinsResultsParserUtil.invokeJenkinsBuild(
+			producerJenkinsMaster, _JOB_NAME, buildParameters);
+
+		setControllerBuildURL(getCurrentTopLevelBuildURL());
+		setProducerJenkinsMaster(producerJenkinsMaster);
+		setProducerQueueId(producerQueueId);
+
+		setStatus(Status.IN_QUEUE);
+
+		save();
+	}
+
 	private String _getAxisVariable() {
 		return String.valueOf(getType());
 	}
@@ -434,9 +563,15 @@ public abstract class BaseBundlePersistentResource
 
 	private static final int _MAX_MISSING_COUNT = 2;
 
+	private static final int _MAX_REDISPATCH_ATTEMPTS = 1;
+
+	private static final long _STAMPEDE_CLAIM_VERIFY_TIME = 1000 * 10;
+
 	private Build _build;
 	private int _failCount;
 	private int _missingCount;
+	private int _redispatchAttempts;
+	private JSONArray _redispatchHistoryJSONArray = new JSONArray();
 	private final TopLevelBuild _topLevelBuild;
 	private Workspace _workspace;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BaseBundlePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BaseBundlePersistentResource.java
@@ -327,8 +327,10 @@ public abstract class BaseBundlePersistentResource
 
 				if (_failCount <= _MAX_FAIL_COUNT) {
 					print(
-						"Retry " + _failCount + " of " + _MAX_FAIL_COUNT +
-							" due to FAILURE in " + getProducerBuildURL());
+						JenkinsResultsParserUtil.combine(
+							"Retry ", String.valueOf(_failCount), " of ",
+							String.valueOf(_MAX_FAIL_COUNT),
+							" due to FAILURE in ", getProducerBuildURL()));
 
 					start();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
@@ -347,6 +347,9 @@ public abstract class BasePersistentResource implements PersistentResource {
 			apiJSONObject.optString("result"));
 	}
 
+	protected void populateDataJSONObject(JSONObject dataJSONObject) {
+	}
+
 	protected void print(String message) {
 		System.out.println("[" + getType() + "] " + message);
 	}
@@ -380,6 +383,8 @@ public abstract class BasePersistentResource implements PersistentResource {
 		).put(
 			"status", String.valueOf(getStatus())
 		);
+
+		populateDataJSONObject(dataJSONObject);
 
 		if (!isBuildCachingEnabled()) {
 			_dataJSONObject = dataJSONObject;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7500

## What Is Being Fixed

BaseBundlePersistentResource caches bundle-builder outcomes in S3 keyed by repo SHAs. When a bundle-builder fails transiently (cold slave, OOM, docker hiccup, slave restart), the controller exhausts its retry budget and writes FAILED; every later build at that SHA inherits FAILED without ever re-running the build. For com-liferay-osb-asah-private (very low commit frequency) a poisoned entry persists for hours-to-days, breaking AC tests on every dispatch in that window.

## How It Is Being Fixed

The follower path now treats a cached FAILED as cache-miss-like. A follower reading FAILED with redispatch budget remaining promotes itself to controller and dispatches a fresh bundle-builder: it writes an IN_QUEUE claim before a short verification sleep, re-reads the entry, and the build whose claim survives dispatches while the rest attach to it as followers. A redispatch_attempts counter (cap 1) plus a bounded redispatch_history persist in data.json.gz, so a genuinely broken build stops re-dispatching and returns FAILED thereafter. The dispatch logic is shared with start() via _invokeBuild(), and BasePersistentResource gains a populateDataJSONObject() hook so the subclass persists the new fields without duplicating save(). Follow-up commits apply review feedback: verb-first method names and JenkinsResultsParserUtil.combine for the redispatch message (from the previous round, pyoo47#4324 → brianchandotcom#175909), getter-mirrored local names with alphabetized independent assignments, and combine for the pre-existing retry message so the file uses one message form.

## Why Are There No Tests?

The persistent.resource package has no unit test coverage and its S3 interactions go through static CloudBucketUtil calls, which makes isolated JVM tests impractical. The change was validated end-to-end on the test-5-1 sandbox with seeded cache entries covering re-dispatch on FAILED, the retry cap (entry returned byte-identical), and unchanged SUCCESS inheritance — evidence recorded on LRCI-7500.

## PR Check

**pr-check: PASS** — tested on `6f632e16f815811e5b3ec73f78c1f3e33b1fdad5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

Notes: Structural Smoke's Log4jConfigUtilTest coverage gate fails identically against current master (upstream LPD-88934 churn; diff touches modules/test only). Java Unit Tests: 74 run, 0 new failures vs the clean-master baseline on the same machine (3 shared environment-path assertions; 8 worktree-name artifacts in BaseRelevantRuleTestCase.getPortalDir).

<!-- pr-check {"result": "success", "sha": "6f632e16f815811e5b3ec73f78c1f3e33b1fdad5"} -->
