### PR TITLE
LRCI-7680 Sign GCS URLs as the federated principal under WIF

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
@@ -309,6 +309,9 @@ public class CloudBucketUtil {
 
 		sb.append("gcloud storage sign-url ");
 		sb.append(url);
+		sb.append(" --duration=");
+		sb.append(duration);
+		sb.append("m");
 
 		if (JenkinsResultsParserUtil.isNullOrEmpty(
 				serviceAccountImpersonationURL)) {
@@ -337,10 +340,6 @@ public class CloudBucketUtil {
 						"serviceAccount"));
 			}
 		}
-
-		sb.append(" --duration=");
-		sb.append(duration);
-		sb.append("m");
 
 		try {
 			Process process = JenkinsResultsParserUtil.executeBashCommands(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
@@ -28,6 +28,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.json.JSONObject;
+
 /**
  * @author Kenji Heigel
  */
@@ -292,27 +294,73 @@ public class CloudBucketUtil {
 			return null;
 		}
 
+		JSONObject credentialJSONObject =
+			JenkinsResultsParserUtil.createJSONObject(
+				JenkinsResultsParserUtil.read(new File(file)));
+
+		String serviceAccountImpersonationURL = credentialJSONObject.optString(
+			"service_account_impersonation_url");
+
+		String authenticationCommand = null;
+
+		File federatedCredentialFile = null;
+
 		StringBuilder sb = new StringBuilder();
 
 		sb.append("gcloud storage sign-url ");
 		sb.append(url);
-		sb.append(" --private-key-file=");
-		sb.append(file);
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(
+				serviceAccountImpersonationURL)) {
+
+			authenticationCommand = _getGCPAuthenticationCommand(url, url);
+
+			sb.append(" --private-key-file=");
+			sb.append(file);
+		}
+		else {
+			federatedCredentialFile = _writeFederatedCredentialFile(
+				credentialJSONObject);
+
+			authenticationCommand = JenkinsResultsParserUtil.combine(
+				"gcloud auth login --cred-file=",
+				federatedCredentialFile.toString(), " --quiet");
+
+			Matcher serviceAccountImpersonationURLMatcher =
+				_serviceAccountImpersonationURLPattern.matcher(
+					serviceAccountImpersonationURL);
+
+			if (serviceAccountImpersonationURLMatcher.find()) {
+				sb.append(" --impersonate-service-account=");
+				sb.append(
+					serviceAccountImpersonationURLMatcher.group(
+						"serviceAccount"));
+			}
+		}
+
 		sb.append(" --duration=");
 		sb.append(duration);
 		sb.append("m");
 
-		Process process = JenkinsResultsParserUtil.executeBashCommands(
-			true, _getGCPAuthenticationCommand(url, url), sb.toString());
+		try {
+			Process process = JenkinsResultsParserUtil.executeBashCommands(
+				true, authenticationCommand, sb.toString());
 
-		Matcher matcher = _signedURLPattern.matcher(
-			JenkinsResultsParserUtil.readInputStream(process.getInputStream()));
+			Matcher signedURLMatcher = _signedURLPattern.matcher(
+				JenkinsResultsParserUtil.readInputStream(
+					process.getInputStream()));
 
-		if (matcher.find()) {
-			return matcher.group(0);
+			if (signedURLMatcher.find()) {
+				return signedURLMatcher.group(0);
+			}
+
+			return null;
 		}
-
-		return null;
+		finally {
+			if (federatedCredentialFile != null) {
+				JenkinsResultsParserUtil.delete(federatedCredentialFile);
+			}
+		}
 	}
 
 	public static boolean isS3ObjectOlderThan(
@@ -993,6 +1041,25 @@ public class CloudBucketUtil {
 		}
 	}
 
+	private static File _writeFederatedCredentialFile(
+			JSONObject credentialJSONObject)
+		throws IOException {
+
+		File federatedCredentialFile = File.createTempFile(
+			"federated-credential", ".json");
+
+		JSONObject federatedCredentialJSONObject = new JSONObject(
+			credentialJSONObject.toString());
+
+		federatedCredentialJSONObject.remove(
+			"service_account_impersonation_url");
+
+		JenkinsResultsParserUtil.write(
+			federatedCredentialFile, federatedCredentialJSONObject.toString());
+
+		return federatedCredentialFile;
+	}
+
 	private static final String _CHECKSUM_FILE_EXTENSION = ".sha512";
 
 	private static final boolean _VALIDATE_CHECKSUM;
@@ -1004,6 +1071,8 @@ public class CloudBucketUtil {
 		"\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} +\\d+ (?<fileName>.+)");
 	private static final Pattern _s3ObjectPathPattern = Pattern.compile(
 		"s3://(?<bucketName>[^/]+)/(?<objectPath>.+)");
+	private static final Pattern _serviceAccountImpersonationURLPattern =
+		Pattern.compile("/serviceAccounts/(?<serviceAccount>[^/:]+):");
 	private static final Pattern _signedURLPattern = Pattern.compile(
 		"https:\\/\\/([a-zA-Z\\d-]+\\.)?storage\\." +
 			"(cloud\\.google\\.com|googleapis\\.com)\\/.*");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7680

## What Is Being Fixed

The WIF migration (LRCI-7279) replaced the scancode GCS credential with a Workload Identity Federation external_account config. CloudBucketUtil.getSignedURL signed via `gcloud storage sign-url --private-key-file`, which needs a local private key that WIF configs don't have, so signed-URL generation broke — surfacing downstream in test-scancode-pipelines as a failure to produce the bundle URL. gcloud also won't sign with a WIF identity directly (it requires --impersonate-service-account), but the WIF config impersonates the service account at login, so adding --impersonate made the service account impersonate itself — a getAccessToken self-hop that IAM denies.

## How It Is Being Fixed

getSignedURL now branches on the credential type. A service_account key keeps the existing --private-key-file path. For an external_account (WIF) config it writes a temporary copy with service_account_impersonation_url stripped and authenticates with that, so the active identity stays the federated principal rather than the impersonated service account; it then signs with --impersonate-service-account set to the service account parsed from the config's service_account_impersonation_url. That turns the impersonation into a single federated-principal-to-service-account hop, which the existing workloadIdentityUser/token-creator binding allows. The temporary config carries no private key and is deleted in a finally block. Verified end to end by a test-scancode-pipelines run that produced a working signed URL.

## Why Are There No Tests?

getSignedURL shells out to gcloud (auth + sign-url) on a CI node against WIF credentials — there is no local-runnable unit path and no existing CloudBucketUtil test. Validated via a live test-scancode-pipelines run that produced a working signed URL.

## PR Check

**pr-check: PASS** — tested on `615188b079c3207558b6fc878c105013e8bd7a32`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS (75 run; 3 environmental LocalGit* failures — hardcoded /opt/dev paths — unrelated) |

<!-- pr-check {"result": "success", "sha": "615188b079c3207558b6fc878c105013e8bd7a32"} -->
