### PR TITLE
LRCI-7840 Fix incorrect Slack emoji for ScanCode notification

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/BaseScanCodePipeline.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/BaseScanCodePipeline.java
@@ -377,7 +377,7 @@ public abstract class BaseScanCodePipeline implements ScanCodePipeline {
 		String subject = "ScanCode pipeline is complete";
 
 		if (hasFailedScan()) {
-			subject = "ScanCode pipeline has failed :red-circle:";
+			subject = "ScanCode pipeline has failed :red_circle:";
 		}
 		else if (_hasErrors()) {
 			subject = ":red-alert: Release blocker :red-alert:";


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7840

## What Is Being Fixed

The ScanCode pipeline failure notification put the literal text `:red-circle:` in its Slack subject line. Slack emoji shortcodes use underscores, so `:red-circle:` never rendered as the emoji — it showed as raw text.

## How It Is Being Fixed

Corrected the shortcode in `BaseScanCodePipeline` from `:red-circle:` to `:red_circle:` so Slack renders the intended red circle in the "ScanCode pipeline has failed" subject.

## Why Are There No Tests?

This corrects a Slack emoji shortcode string constant; there is no behavioral logic to test.

## PR Check

**pr-check: PASS** — tested on `731b83eff462eefb9e80f65265df58ed681dcbb2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | N/A — no counterpart test; full module suite not run |

<!-- pr-check {"result": "success", "sha": "731b83eff462eefb9e80f65265df58ed681dcbb2"} -->
