### PR TITLE
LRCI-7958 Add the metrics emitter MonitorMetricsWriter

### DIFF
--- a/modules/test/jenkins-results-parser/build.gradle
+++ b/modules/test/jenkins-results-parser/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	api group: "com.sun.mail", name: "jakarta.mail", version: "2.0.1"
 	api group: "commons-codec", name: "commons-codec", version: "1.15"
 	api group: "commons-io", name: "commons-io", version: "2.19.0"
+	api group: "io.prometheus", name: "prometheus-metrics-exposition-textformats", version: "1.8.0"
 	api group: "junit", name: "junit", version: "4.13.1"
 	api group: "org.apache.ant", name: "ant", version: "1.10.14"
 	api group: "org.apache.commons", name: "commons-compress", version: "1.26.0"

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorEngine.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorEngine.java
@@ -7,6 +7,8 @@ package com.liferay.jenkins.results.parser.monitor;
 
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -21,7 +23,7 @@ public class MonitorEngine {
 		MonitorIdValidator.validate(monitors);
 
 		_monitorResultStore = monitorResultStore;
-		_monitors = monitors;
+		_monitors = Collections.unmodifiableList(new ArrayList<>(monitors));
 
 		_monitorScheduler = new MonitorScheduler(monitorResultStore);
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorEngine.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorEngine.java
@@ -18,6 +18,8 @@ public class MonitorEngine {
 	public MonitorEngine(
 		MonitorResultStore monitorResultStore, List<Monitor> monitors) {
 
+		MonitorIdValidator.validate(monitors);
+
 		_monitorResultStore = monitorResultStore;
 		_monitors = monitors;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorIdValidator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorIdValidator.java
@@ -5,6 +5,8 @@
 
 package com.liferay.jenkins.results.parser.monitor;
 
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -19,6 +21,10 @@ public class MonitorIdValidator {
 
 		for (Monitor monitor : monitors) {
 			String id = monitor.getId();
+
+			if (JenkinsResultsParserUtil.isNullOrEmpty(id)) {
+				throw new IllegalArgumentException("Null or empty monitor ID");
+			}
 
 			if (!ids.add(id)) {
 				throw new IllegalArgumentException(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorIdValidator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorIdValidator.java
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorIdValidator {
+
+	public static void validate(List<Monitor> monitors) {
+		Set<String> ids = new HashSet<>();
+
+		for (Monitor monitor : monitors) {
+			String id = monitor.getId();
+
+			if (!ids.add(id)) {
+				throw new IllegalArgumentException(
+					"Duplicate monitor ID: " + id);
+			}
+		}
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
@@ -7,6 +7,13 @@ package com.liferay.jenkins.results.parser.monitor;
 
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 
+import io.prometheus.metrics.config.EscapingScheme;
+import io.prometheus.metrics.expositionformats.PrometheusTextFormatWriter;
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
+import io.prometheus.metrics.model.snapshots.Labels;
+import io.prometheus.metrics.model.snapshots.MetricSnapshots;
+
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 
@@ -43,61 +50,72 @@ public class MonitorMetricsWriter {
 			StandardCopyOption.ATOMIC_MOVE);
 	}
 
-	private String _escapeLabelValue(String labelValue) {
-		labelValue = labelValue.replace("\\", "\\\\");
+	private GaugeSnapshot _getCheckLastRunTimestampSnapshot() {
+		GaugeSnapshot.Builder builder = GaugeSnapshot.builder();
 
-		labelValue = labelValue.replace("\"", "\\\"");
-
-		return labelValue.replace("\n", "\\n");
-	}
-
-	private String _getCheckLastRunTimestampLine(Monitor monitor) {
-		return JenkinsResultsParserUtil.combine(
-			"monitor_check_last_run_timestamp_seconds{", _getLabels(monitor),
-			"} ", String.valueOf(_getLastRunTimestampSeconds(monitor)));
-	}
-
-	private String _getCheckStatusLine(Monitor monitor) {
-		return JenkinsResultsParserUtil.combine(
-			"monitor_check_status{", _getLabels(monitor), "} ",
-			String.valueOf(_getSeverityRank(monitor)));
-	}
-
-	private String _getContent() {
-		StringBuilder sb = new StringBuilder();
-
-		sb.append(
-			"# HELP monitor_check_status Monitor status severity rank, 0 OK, " +
-				"1 UNKNOWN, 2 WARN, 3 CRITICAL\n");
-		sb.append("# TYPE monitor_check_status gauge\n");
+		builder.name("monitor_check_last_run_timestamp_seconds");
+		builder.help("Unix timestamp of the last check run, 0 if never run");
 
 		for (Monitor monitor : _monitors) {
-			sb.append(_getCheckStatusLine(monitor));
-			sb.append("\n");
+			builder.dataPoint(
+				_newGaugeDataPointSnapshot(
+					monitor, _getLastRunTimestampSeconds(monitor)));
 		}
 
-		sb.append(
-			"# HELP monitor_check_last_run_timestamp_seconds Unix timestamp " +
-				"of the last check run, 0 if never run\n");
-		sb.append("# TYPE monitor_check_last_run_timestamp_seconds gauge\n");
-
-		for (Monitor monitor : _monitors) {
-			sb.append(_getCheckLastRunTimestampLine(monitor));
-			sb.append("\n");
-		}
-
-		sb.append(
-			"# HELP monitor_heartbeat_timestamp_seconds Unix timestamp of " +
-				"the last metrics write\n");
-		sb.append("# TYPE monitor_heartbeat_timestamp_seconds gauge\n");
-		sb.append("monitor_heartbeat_timestamp_seconds ");
-		sb.append(JenkinsResultsParserUtil.getCurrentTimeMillis() / 1000);
-		sb.append("\n");
-
-		return sb.toString();
+		return builder.build();
 	}
 
-	private String _getLabels(Monitor monitor) {
+	private GaugeSnapshot _getCheckStatusSnapshot() {
+		GaugeSnapshot.Builder builder = GaugeSnapshot.builder();
+
+		builder.name("monitor_check_status");
+		builder.help(
+			"Monitor status severity rank, 0 OK, 1 UNKNOWN, 2 WARN, 3 " +
+				"CRITICAL");
+
+		for (Monitor monitor : _monitors) {
+			builder.dataPoint(
+				_newGaugeDataPointSnapshot(monitor, _getSeverityRank(monitor)));
+		}
+
+		return builder.build();
+	}
+
+	private String _getContent() throws IOException {
+		ByteArrayOutputStream byteArrayOutputStream =
+			new ByteArrayOutputStream();
+
+		PrometheusTextFormatWriter prometheusTextFormatWriter =
+			PrometheusTextFormatWriter.create();
+
+		prometheusTextFormatWriter.write(
+			byteArrayOutputStream,
+			MetricSnapshots.of(
+				_getCheckLastRunTimestampSnapshot(), _getCheckStatusSnapshot(),
+				_getHeartbeatTimestampSnapshot()),
+			EscapingScheme.DEFAULT);
+
+		return byteArrayOutputStream.toString("UTF-8");
+	}
+
+	private GaugeSnapshot _getHeartbeatTimestampSnapshot() {
+		GaugeSnapshot.Builder builder = GaugeSnapshot.builder();
+
+		builder.name("monitor_heartbeat_timestamp_seconds");
+		builder.help("Unix timestamp of the last metrics write");
+
+		GaugeSnapshot.GaugeDataPointSnapshot.Builder dataPointBuilder =
+			GaugeSnapshot.GaugeDataPointSnapshot.builder();
+
+		dataPointBuilder.value(
+			JenkinsResultsParserUtil.getCurrentTimeMillis() / 1000);
+
+		builder.dataPoint(dataPointBuilder.build());
+
+		return builder.build();
+	}
+
+	private Labels _getLabels(Monitor monitor) {
 		MonitorConfig monitorConfig = monitor.getMonitorConfig();
 
 		MonitorConfig.Severity severity = monitorConfig.getSeverity();
@@ -114,10 +132,9 @@ public class MonitorMetricsWriter {
 			type = "unknown";
 		}
 
-		return JenkinsResultsParserUtil.combine(
-			"check=\"", _escapeLabelValue(monitor.getId()), "\",severity=\"",
-			severityName.toLowerCase(Locale.ENGLISH), "\",type=\"",
-			_escapeLabelValue(type), "\"");
+		return Labels.of(
+			"check", monitor.getId(), "severity",
+			severityName.toLowerCase(Locale.ENGLISH), "type", type);
 	}
 
 	private long _getLastRunTimestampSeconds(Monitor monitor) {
@@ -146,6 +163,18 @@ public class MonitorMetricsWriter {
 		}
 
 		return status.getSeverityRank();
+	}
+
+	private GaugeSnapshot.GaugeDataPointSnapshot _newGaugeDataPointSnapshot(
+		Monitor monitor, double value) {
+
+		GaugeSnapshot.GaugeDataPointSnapshot.Builder dataPointBuilder =
+			GaugeSnapshot.GaugeDataPointSnapshot.builder();
+
+		dataPointBuilder.labels(_getLabels(monitor));
+		dataPointBuilder.value(value);
+
+		return dataPointBuilder.build();
 	}
 
 	private final File _metricsFile;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
@@ -130,7 +130,7 @@ public class MonitorMetricsWriter {
 
 		String type = monitorConfig.getType();
 
-		if (type == null) {
+		if (JenkinsResultsParserUtil.isNullOrEmpty(type)) {
 			type = "unknown";
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -36,7 +38,7 @@ public class MonitorMetricsWriter {
 
 		_metricsFile = metricsFile;
 		_monitorResultStore = monitorResultStore;
-		_monitors = monitors;
+		_monitors = Collections.unmodifiableList(new ArrayList<>(monitors));
 	}
 
 	public void write() throws IOException {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
@@ -25,6 +25,8 @@ public class MonitorMetricsWriter {
 		File metricsFile, MonitorResultStore monitorResultStore,
 		List<Monitor> monitors) {
 
+		MonitorIdValidator.validate(monitors);
+
 		_metricsFile = metricsFile;
 		_monitorResultStore = monitorResultStore;
 		_monitors = monitors;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
@@ -1,0 +1,153 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorMetricsWriter {
+
+	public MonitorMetricsWriter(
+		File metricsFile, MonitorResultStore monitorResultStore,
+		List<Monitor> monitors) {
+
+		_metricsFile = metricsFile;
+		_monitorResultStore = monitorResultStore;
+		_monitors = monitors;
+	}
+
+	public void write() throws IOException {
+		File temporaryFile = new File(
+			_metricsFile.getParentFile(), _metricsFile.getName() + ".tmp");
+
+		JenkinsResultsParserUtil.write(temporaryFile, _getContent());
+
+		Files.move(
+			temporaryFile.toPath(), _metricsFile.toPath(),
+			StandardCopyOption.ATOMIC_MOVE);
+	}
+
+	private String _escapeLabelValue(String labelValue) {
+		labelValue = labelValue.replace("\\", "\\\\");
+
+		labelValue = labelValue.replace("\"", "\\\"");
+
+		return labelValue.replace("\n", "\\n");
+	}
+
+	private String _getCheckLastRunTimestampLine(Monitor monitor) {
+		return JenkinsResultsParserUtil.combine(
+			"monitor_check_last_run_timestamp_seconds{", _getLabels(monitor),
+			"} ", String.valueOf(_getLastRunTimestampSeconds(monitor)));
+	}
+
+	private String _getCheckStatusLine(Monitor monitor) {
+		return JenkinsResultsParserUtil.combine(
+			"monitor_check_status{", _getLabels(monitor), "} ",
+			String.valueOf(_getSeverityRank(monitor)));
+	}
+
+	private String _getContent() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append(
+			"# HELP monitor_check_status Monitor status severity rank, 0 OK, " +
+				"1 UNKNOWN, 2 WARN, 3 CRITICAL\n");
+		sb.append("# TYPE monitor_check_status gauge\n");
+
+		for (Monitor monitor : _monitors) {
+			sb.append(_getCheckStatusLine(monitor));
+			sb.append("\n");
+		}
+
+		sb.append(
+			"# HELP monitor_check_last_run_timestamp_seconds Unix timestamp " +
+				"of the last check run, 0 if never run\n");
+		sb.append("# TYPE monitor_check_last_run_timestamp_seconds gauge\n");
+
+		for (Monitor monitor : _monitors) {
+			sb.append(_getCheckLastRunTimestampLine(monitor));
+			sb.append("\n");
+		}
+
+		sb.append(
+			"# HELP monitor_heartbeat_timestamp_seconds Unix timestamp of " +
+				"the last metrics write\n");
+		sb.append("# TYPE monitor_heartbeat_timestamp_seconds gauge\n");
+		sb.append("monitor_heartbeat_timestamp_seconds ");
+		sb.append(JenkinsResultsParserUtil.getCurrentTimeMillis() / 1000);
+		sb.append("\n");
+
+		return sb.toString();
+	}
+
+	private String _getLabels(Monitor monitor) {
+		MonitorConfig monitorConfig = monitor.getMonitorConfig();
+
+		MonitorConfig.Severity severity = monitorConfig.getSeverity();
+
+		if (severity == null) {
+			severity = MonitorConfig.Severity.MEDIUM;
+		}
+
+		String severityName = severity.name();
+
+		String type = monitorConfig.getType();
+
+		if (type == null) {
+			type = "unknown";
+		}
+
+		return JenkinsResultsParserUtil.combine(
+			"check=\"", _escapeLabelValue(monitor.getId()), "\",severity=\"",
+			severityName.toLowerCase(Locale.ENGLISH), "\",type=\"",
+			_escapeLabelValue(type), "\"");
+	}
+
+	private long _getLastRunTimestampSeconds(Monitor monitor) {
+		MonitorResult monitorResult =
+			_monitorResultStore.getLatestMonitorResult(monitor.getId());
+
+		if (monitorResult == null) {
+			return 0;
+		}
+
+		return monitorResult.getTimestamp() / 1000;
+	}
+
+	private int _getSeverityRank(Monitor monitor) {
+		MonitorResult monitorResult =
+			_monitorResultStore.getLatestMonitorResult(monitor.getId());
+
+		if (monitorResult == null) {
+			return MonitorResult.Status.UNKNOWN.getSeverityRank();
+		}
+
+		MonitorResult.Status status = monitorResult.getStatus();
+
+		if (status == null) {
+			return MonitorResult.Status.UNKNOWN.getSeverityRank();
+		}
+
+		return status.getSeverityRank();
+	}
+
+	private final File _metricsFile;
+	private final MonitorResultStore _monitorResultStore;
+	private final List<Monitor> _monitors;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorResult.java
@@ -61,6 +61,10 @@ public class MonitorResult {
 			return mostSevereStatus;
 		}
 
+		public int getSeverityRank() {
+			return _severityRank;
+		}
+
 		private Status(int severityRank) {
 			_severityRank = severityRank;
 		}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorEngineTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorEngineTest.java
@@ -8,6 +8,7 @@ package com.liferay.jenkins.results.parser.monitor;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 import com.liferay.jenkins.results.parser.RandomTestUtil;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -175,6 +176,23 @@ public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
 
 			testEquals(2, monitorResults.size());
 		}
+	}
+
+	@Test(timeout = 10000)
+	public void testRunCycleIgnoresMonitorsAddedAfterConstruction() {
+		List<Monitor> monitors = new ArrayList<>();
+
+		monitors.add(new TestMonitor(_newMonitorConfig("a", 0, 0)));
+
+		MonitorEngine monitorEngine = new MonitorEngine(
+			new MonitorResultStore(), monitors);
+
+		monitors.add(new TestMonitor(_newMonitorConfig("b", 0, 0)));
+
+		Map<Monitor, MonitorResult> monitorResultsMap =
+			monitorEngine.runCycle();
+
+		testEquals(1, monitorResultsMap.size());
 	}
 
 	private MonitorConfig _newMonitorConfig(String id) {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorEngineTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorEngineTest.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import org.mockito.MockedStatic;
@@ -21,6 +22,29 @@ import org.mockito.Mockito;
  * @author Brittney Nguyen
  */
 public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testMonitorEngineDuplicateIds() {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		new MonitorEngine(
+			monitorResultStore,
+			Arrays.<Monitor>asList(
+				new TestMonitor(_newMonitorConfig("a")),
+				new TestMonitor(_newMonitorConfig("b"))));
+
+		try {
+			new MonitorEngine(
+				monitorResultStore,
+				Arrays.<Monitor>asList(
+					new TestMonitor(_newMonitorConfig("a")),
+					new TestMonitor(_newMonitorConfig("a"))));
+
+			Assert.fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+		}
+	}
 
 	@Test(timeout = 10000)
 	public void testRunCycle() {
@@ -151,6 +175,11 @@ public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
 
 			testEquals(2, monitorResults.size());
 		}
+	}
+
+	private MonitorConfig _newMonitorConfig(String id) {
+		return _newMonitorConfig(
+			id, RandomTestUtil.randomLong(), RandomTestUtil.randomLong());
 	}
 
 	private MonitorConfig _newMonitorConfig(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorIdValidatorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorIdValidatorTest.java
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.RandomTestUtil;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorIdValidatorTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testValidate() {
+		MonitorIdValidator.validate(Collections.<Monitor>emptyList());
+
+		MonitorIdValidator.validate(
+			Arrays.<Monitor>asList(_newMonitor("a"), _newMonitor("b")));
+
+		try {
+			MonitorIdValidator.validate(
+				Arrays.<Monitor>asList(_newMonitor("a"), _newMonitor("a")));
+
+			Assert.fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+		}
+	}
+
+	private Monitor _newMonitor(String id) {
+		return new TestMonitor(
+			new MonitorConfig(
+				id, RandomTestUtil.randomLong(), null,
+				MonitorConfig.Severity.MEDIUM, null,
+				RandomTestUtil.randomLong(), RandomTestUtil.randomString()));
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorIdValidatorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorIdValidatorTest.java
@@ -34,6 +34,24 @@ public class MonitorIdValidatorTest
 		}
 		catch (IllegalArgumentException illegalArgumentException) {
 		}
+
+		try {
+			MonitorIdValidator.validate(
+				Arrays.<Monitor>asList(_newMonitor("a"), _newMonitor(null)));
+
+			Assert.fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+		}
+
+		try {
+			MonitorIdValidator.validate(
+				Arrays.<Monitor>asList(_newMonitor("a"), _newMonitor("")));
+
+			Assert.fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+		}
 	}
 
 	private Monitor _newMonitor(String id) {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
@@ -10,6 +10,7 @@ import com.liferay.jenkins.results.parser.RandomTestUtil;
 
 import java.io.File;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -121,6 +122,56 @@ public class MonitorMetricsWriterTest
 			content.contains(
 				"monitor_check_status{check=\"a\\\"b\\\\c\"," +
 					"severity=\"medium\",type=\"d\\ne\"} 2.0\n"));
+	}
+
+	@Test
+	public void testWriteIgnoresMonitorsAddedAfterConstruction()
+		throws Exception {
+
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		monitorResultStore.store(
+			"disk", _newMonitorResult(MonitorResult.Status.OK, 1750000000000L));
+
+		List<Monitor> monitors = new ArrayList<>();
+
+		monitors.add(
+			new TestMonitor(
+				_newMonitorConfig(
+					"disk", MonitorConfig.Severity.HIGH,
+					"resource-threshold")));
+
+		File metricsFile = new File(
+			temporaryFolder.getRoot(), RandomTestUtil.randomString());
+
+		MonitorMetricsWriter monitorMetricsWriter = new MonitorMetricsWriter(
+			metricsFile, monitorResultStore, monitors);
+
+		monitors.add(
+			new TestMonitor(
+				_newMonitorConfig(
+					"disk", MonitorConfig.Severity.HIGH,
+					"resource-threshold")));
+
+		_write(monitorMetricsWriter);
+
+		testEquals(
+			JenkinsResultsParserUtil.combine(
+				"# HELP monitor_check_last_run_timestamp_seconds Unix ",
+				"timestamp of the last check run, 0 if never run\n",
+				"# TYPE monitor_check_last_run_timestamp_seconds gauge\n",
+				"monitor_check_last_run_timestamp_seconds{check=\"disk\",",
+				"severity=\"high\",type=\"resource-threshold\"} 1.75E9\n",
+				"# HELP monitor_check_status Monitor status severity rank, ",
+				"0 OK, 1 UNKNOWN, 2 WARN, 3 CRITICAL\n",
+				"# TYPE monitor_check_status gauge\n",
+				"monitor_check_status{check=\"disk\",severity=\"high\",",
+				"type=\"resource-threshold\"} 0.0\n",
+				"# HELP monitor_heartbeat_timestamp_seconds Unix timestamp of ",
+				"the last metrics write\n",
+				"# TYPE monitor_heartbeat_timestamp_seconds gauge\n",
+				"monitor_heartbeat_timestamp_seconds 1.75E9\n"),
+			read(metricsFile));
 	}
 
 	@Test
@@ -237,8 +288,13 @@ public class MonitorMetricsWriterTest
 			List<Monitor> monitors)
 		throws Exception {
 
-		MonitorMetricsWriter monitorMetricsWriter = new MonitorMetricsWriter(
-			metricsFile, monitorResultStore, monitors);
+		_write(
+			new MonitorMetricsWriter(
+				metricsFile, monitorResultStore, monitors));
+	}
+
+	private void _write(MonitorMetricsWriter monitorMetricsWriter)
+		throws Exception {
 
 		try (MockedStatic<JenkinsResultsParserUtil>
 				jenkinsResultsParserUtilMockedStatic = Mockito.mockStatic(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
@@ -1,0 +1,235 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.RandomTestUtil;
+
+import java.io.File;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorMetricsWriterTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testWrite() throws Exception {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		monitorResultStore.store(
+			"disk",
+			_newMonitorResult(MonitorResult.Status.CRITICAL, 1750000000000L));
+		monitorResultStore.store(
+			"queue",
+			_newMonitorResult(MonitorResult.Status.OK, 1749999000000L));
+
+		File metricsFile = new File(
+			temporaryFolder.getRoot(),
+			RandomTestUtil.randomString() + "/" +
+				RandomTestUtil.randomString());
+
+		_write(metricsFile, monitorResultStore, _newMonitors());
+
+		testEquals(
+			JenkinsResultsParserUtil.combine(
+				"# HELP monitor_check_status Monitor status severity rank, ",
+				"0 OK, 1 UNKNOWN, 2 WARN, 3 CRITICAL\n",
+				"# TYPE monitor_check_status gauge\n",
+				"monitor_check_status{check=\"disk\",severity=\"high\",",
+				"type=\"resource-threshold\"} 3\n",
+				"monitor_check_status{check=\"queue\",severity=\"medium\",",
+				"type=\"job-health\"} 0\n",
+				"monitor_check_status{check=\"testray\",severity=\"low\",",
+				"type=\"external-status\"} 1\n",
+				"# HELP monitor_check_last_run_timestamp_seconds Unix ",
+				"timestamp of the last check run, 0 if never run\n",
+				"# TYPE monitor_check_last_run_timestamp_seconds gauge\n",
+				"monitor_check_last_run_timestamp_seconds{check=\"disk\",",
+				"severity=\"high\",type=\"resource-threshold\"} 1750000000\n",
+				"monitor_check_last_run_timestamp_seconds{check=\"queue\",",
+				"severity=\"medium\",type=\"job-health\"} 1749999000\n",
+				"monitor_check_last_run_timestamp_seconds{check=\"testray\",",
+				"severity=\"low\",type=\"external-status\"} 0\n",
+				"# HELP monitor_heartbeat_timestamp_seconds Unix timestamp of ",
+				"the last metrics write\n",
+				"# TYPE monitor_heartbeat_timestamp_seconds gauge\n",
+				"monitor_heartbeat_timestamp_seconds 1750000000\n"),
+			read(metricsFile));
+	}
+
+	@Test
+	public void testWriteEscapesLabelValues() throws Exception {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		monitorResultStore.store(
+			"a\"b\\c",
+			_newMonitorResult(
+				MonitorResult.Status.WARN, RandomTestUtil.randomLong()));
+
+		File metricsFile = new File(
+			temporaryFolder.getRoot(), RandomTestUtil.randomString());
+
+		_write(
+			metricsFile, monitorResultStore,
+			Arrays.<Monitor>asList(
+				new TestMonitor(
+					_newMonitorConfig(
+						"a\"b\\c", MonitorConfig.Severity.MEDIUM, "d\ne"))));
+
+		String content = read(metricsFile);
+
+		Assert.assertTrue(
+			content,
+			content.contains(
+				"monitor_check_status{check=\"a\\\"b\\\\c\"," +
+					"severity=\"medium\",type=\"d\\ne\"} 2\n"));
+	}
+
+	@Test
+	public void testWriteNullSeverityAndType() throws Exception {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		monitorResultStore.store(
+			"disk",
+			_newMonitorResult(
+				MonitorResult.Status.OK, RandomTestUtil.randomLong()));
+
+		File metricsFile = new File(
+			temporaryFolder.getRoot(), RandomTestUtil.randomString());
+
+		_write(
+			metricsFile, monitorResultStore,
+			Arrays.<Monitor>asList(
+				new TestMonitor(
+					new MonitorConfig(
+						"disk", RandomTestUtil.randomLong(), null, null, null,
+						RandomTestUtil.randomLong(), null))));
+
+		String content = read(metricsFile);
+
+		Assert.assertTrue(
+			content,
+			content.contains(
+				"monitor_check_status{check=\"disk\"," +
+					"severity=\"medium\",type=\"unknown\"} 0\n"));
+	}
+
+	@Test
+	public void testWriteNullStatus() throws Exception {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		monitorResultStore.store(
+			"disk", _newMonitorResult(null, RandomTestUtil.randomLong()));
+
+		File metricsFile = new File(
+			temporaryFolder.getRoot(), RandomTestUtil.randomString());
+
+		_write(
+			metricsFile, monitorResultStore,
+			Arrays.<Monitor>asList(
+				new TestMonitor(
+					_newMonitorConfig(
+						"disk", MonitorConfig.Severity.HIGH,
+						"resource-threshold"))));
+
+		String content = read(metricsFile);
+
+		Assert.assertTrue(
+			content,
+			content.contains(
+				"monitor_check_status{check=\"disk\",severity=\"high\"," +
+					"type=\"resource-threshold\"} 1\n"));
+	}
+
+	@Test
+	public void testWriteReplacesContent() throws Exception {
+		String metricsFileName = RandomTestUtil.randomString();
+
+		File metricsFile = new File(temporaryFolder.getRoot(), metricsFileName);
+
+		String randomString = RandomTestUtil.randomString();
+
+		JenkinsResultsParserUtil.write(metricsFile, randomString);
+
+		_write(metricsFile, new MonitorResultStore(), _newMonitors());
+
+		String content = read(metricsFile);
+
+		Assert.assertFalse(content, content.contains(randomString));
+
+		File temporaryFile = new File(
+			temporaryFolder.getRoot(), metricsFileName + ".tmp");
+
+		Assert.assertFalse(temporaryFile.exists());
+	}
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private MonitorConfig _newMonitorConfig(
+		String id, MonitorConfig.Severity severity, String type) {
+
+		return new MonitorConfig(
+			id, RandomTestUtil.randomLong(), null, severity, null,
+			RandomTestUtil.randomLong(), type);
+	}
+
+	private MonitorResult _newMonitorResult(
+		MonitorResult.Status status, long timestamp) {
+
+		return new MonitorResult(
+			RandomTestUtil.randomString(), null, status, timestamp);
+	}
+
+	private List<Monitor> _newMonitors() {
+		return Arrays.<Monitor>asList(
+			new TestMonitor(
+				_newMonitorConfig(
+					"disk", MonitorConfig.Severity.HIGH, "resource-threshold")),
+			new TestMonitor(
+				_newMonitorConfig(
+					"queue", MonitorConfig.Severity.MEDIUM, "job-health")),
+			new TestMonitor(
+				_newMonitorConfig(
+					"testray", MonitorConfig.Severity.LOW, "external-status")));
+	}
+
+	private void _write(
+			File metricsFile, MonitorResultStore monitorResultStore,
+			List<Monitor> monitors)
+		throws Exception {
+
+		MonitorMetricsWriter monitorMetricsWriter = new MonitorMetricsWriter(
+			metricsFile, monitorResultStore, monitors);
+
+		try (MockedStatic<JenkinsResultsParserUtil>
+				jenkinsResultsParserUtilMockedStatic = Mockito.mockStatic(
+					JenkinsResultsParserUtil.class,
+					Mockito.CALLS_REAL_METHODS)) {
+
+			jenkinsResultsParserUtilMockedStatic.when(
+				JenkinsResultsParserUtil::getCurrentTimeMillis
+			).thenReturn(
+				1750000000123L
+			);
+
+			monitorMetricsWriter.write();
+		}
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
@@ -97,6 +97,34 @@ public class MonitorMetricsWriterTest
 	}
 
 	@Test
+	public void testWriteEmptyType() throws Exception {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		monitorResultStore.store(
+			"disk",
+			_newMonitorResult(
+				MonitorResult.Status.OK, RandomTestUtil.randomLong()));
+
+		File metricsFile = new File(
+			temporaryFolder.getRoot(), RandomTestUtil.randomString());
+
+		_write(
+			metricsFile, monitorResultStore,
+			Arrays.<Monitor>asList(
+				new TestMonitor(
+					_newMonitorConfig(
+						"disk", MonitorConfig.Severity.HIGH, ""))));
+
+		String content = read(metricsFile);
+
+		Assert.assertTrue(
+			content,
+			content.contains(
+				"monitor_check_status{check=\"disk\",severity=\"high\"," +
+					"type=\"unknown\"} 0.0\n"));
+	}
+
+	@Test
 	public void testWriteEscapesLabelValues() throws Exception {
 		MonitorResultStore monitorResultStore = new MonitorResultStore();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
@@ -28,6 +28,29 @@ public class MonitorMetricsWriterTest
 	extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
+	public void testMonitorMetricsWriterDuplicateIds() {
+		try {
+			new MonitorMetricsWriter(
+				new File(
+					temporaryFolder.getRoot(), RandomTestUtil.randomString()),
+				new MonitorResultStore(),
+				Arrays.<Monitor>asList(
+					new TestMonitor(
+						_newMonitorConfig(
+							"disk", MonitorConfig.Severity.MEDIUM,
+							RandomTestUtil.randomString())),
+					new TestMonitor(
+						_newMonitorConfig(
+							"disk", MonitorConfig.Severity.MEDIUM,
+							RandomTestUtil.randomString()))));
+
+			Assert.fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+		}
+	}
+
+	@Test
 	public void testWrite() throws Exception {
 		MonitorResultStore monitorResultStore = new MonitorResultStore();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
@@ -70,28 +70,28 @@ public class MonitorMetricsWriterTest
 
 		testEquals(
 			JenkinsResultsParserUtil.combine(
-				"# HELP monitor_check_status Monitor status severity rank, ",
-				"0 OK, 1 UNKNOWN, 2 WARN, 3 CRITICAL\n",
-				"# TYPE monitor_check_status gauge\n",
-				"monitor_check_status{check=\"disk\",severity=\"high\",",
-				"type=\"resource-threshold\"} 3\n",
-				"monitor_check_status{check=\"queue\",severity=\"medium\",",
-				"type=\"job-health\"} 0\n",
-				"monitor_check_status{check=\"testray\",severity=\"low\",",
-				"type=\"external-status\"} 1\n",
 				"# HELP monitor_check_last_run_timestamp_seconds Unix ",
 				"timestamp of the last check run, 0 if never run\n",
 				"# TYPE monitor_check_last_run_timestamp_seconds gauge\n",
 				"monitor_check_last_run_timestamp_seconds{check=\"disk\",",
-				"severity=\"high\",type=\"resource-threshold\"} 1750000000\n",
+				"severity=\"high\",type=\"resource-threshold\"} 1.75E9\n",
 				"monitor_check_last_run_timestamp_seconds{check=\"queue\",",
-				"severity=\"medium\",type=\"job-health\"} 1749999000\n",
+				"severity=\"medium\",type=\"job-health\"} 1.749999E9\n",
 				"monitor_check_last_run_timestamp_seconds{check=\"testray\",",
-				"severity=\"low\",type=\"external-status\"} 0\n",
+				"severity=\"low\",type=\"external-status\"} 0.0\n",
+				"# HELP monitor_check_status Monitor status severity rank, ",
+				"0 OK, 1 UNKNOWN, 2 WARN, 3 CRITICAL\n",
+				"# TYPE monitor_check_status gauge\n",
+				"monitor_check_status{check=\"disk\",severity=\"high\",",
+				"type=\"resource-threshold\"} 3.0\n",
+				"monitor_check_status{check=\"queue\",severity=\"medium\",",
+				"type=\"job-health\"} 0.0\n",
+				"monitor_check_status{check=\"testray\",severity=\"low\",",
+				"type=\"external-status\"} 1.0\n",
 				"# HELP monitor_heartbeat_timestamp_seconds Unix timestamp of ",
 				"the last metrics write\n",
 				"# TYPE monitor_heartbeat_timestamp_seconds gauge\n",
-				"monitor_heartbeat_timestamp_seconds 1750000000\n"),
+				"monitor_heartbeat_timestamp_seconds 1.75E9\n"),
 			read(metricsFile));
 	}
 
@@ -120,7 +120,7 @@ public class MonitorMetricsWriterTest
 			content,
 			content.contains(
 				"monitor_check_status{check=\"a\\\"b\\\\c\"," +
-					"severity=\"medium\",type=\"d\\ne\"} 2\n"));
+					"severity=\"medium\",type=\"d\\ne\"} 2.0\n"));
 	}
 
 	@Test
@@ -149,7 +149,7 @@ public class MonitorMetricsWriterTest
 			content,
 			content.contains(
 				"monitor_check_status{check=\"disk\"," +
-					"severity=\"medium\",type=\"unknown\"} 0\n"));
+					"severity=\"medium\",type=\"unknown\"} 0.0\n"));
 	}
 
 	@Test
@@ -176,7 +176,7 @@ public class MonitorMetricsWriterTest
 			content,
 			content.contains(
 				"monitor_check_status{check=\"disk\",severity=\"high\"," +
-					"type=\"resource-threshold\"} 1\n"));
+					"type=\"resource-threshold\"} 1.0\n"));
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
@@ -156,50 +156,32 @@ public class MonitorMetricsWriterTest
 	public void testWriteIgnoresMonitorsAddedAfterConstruction()
 		throws Exception {
 
-		MonitorResultStore monitorResultStore = new MonitorResultStore();
-
-		monitorResultStore.store(
-			"disk", _newMonitorResult(MonitorResult.Status.OK, 1750000000000L));
-
 		List<Monitor> monitors = new ArrayList<>();
 
 		monitors.add(
 			new TestMonitor(
 				_newMonitorConfig(
-					"disk", MonitorConfig.Severity.HIGH,
-					"resource-threshold")));
+					"disk", MonitorConfig.Severity.MEDIUM,
+					RandomTestUtil.randomString())));
 
 		File metricsFile = new File(
 			temporaryFolder.getRoot(), RandomTestUtil.randomString());
 
 		MonitorMetricsWriter monitorMetricsWriter = new MonitorMetricsWriter(
-			metricsFile, monitorResultStore, monitors);
+			metricsFile, new MonitorResultStore(), monitors);
 
 		monitors.add(
 			new TestMonitor(
 				_newMonitorConfig(
-					"disk", MonitorConfig.Severity.HIGH,
-					"resource-threshold")));
+					"queue", MonitorConfig.Severity.MEDIUM,
+					RandomTestUtil.randomString())));
 
 		_write(monitorMetricsWriter);
 
-		testEquals(
-			JenkinsResultsParserUtil.combine(
-				"# HELP monitor_check_last_run_timestamp_seconds Unix ",
-				"timestamp of the last check run, 0 if never run\n",
-				"# TYPE monitor_check_last_run_timestamp_seconds gauge\n",
-				"monitor_check_last_run_timestamp_seconds{check=\"disk\",",
-				"severity=\"high\",type=\"resource-threshold\"} 1.75E9\n",
-				"# HELP monitor_check_status Monitor status severity rank, ",
-				"0 OK, 1 UNKNOWN, 2 WARN, 3 CRITICAL\n",
-				"# TYPE monitor_check_status gauge\n",
-				"monitor_check_status{check=\"disk\",severity=\"high\",",
-				"type=\"resource-threshold\"} 0.0\n",
-				"# HELP monitor_heartbeat_timestamp_seconds Unix timestamp of ",
-				"the last metrics write\n",
-				"# TYPE monitor_heartbeat_timestamp_seconds gauge\n",
-				"monitor_heartbeat_timestamp_seconds 1.75E9\n"),
-			read(metricsFile));
+		String content = read(metricsFile);
+
+		Assert.assertTrue(content, content.contains("check=\"disk\""));
+		Assert.assertFalse(content, content.contains("check=\"queue\""));
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorResultTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorResultTest.java
@@ -69,4 +69,12 @@ public class MonitorResultTest extends com.liferay.jenkins.results.parser.Test {
 				Collections.<MonitorResult.Status>emptyList()));
 	}
 
+	@Test
+	public void testGetSeverityRank() {
+		testEquals(0, MonitorResult.Status.OK.getSeverityRank());
+		testEquals(1, MonitorResult.Status.UNKNOWN.getSeverityRank());
+		testEquals(2, MonitorResult.Status.WARN.getSeverityRank());
+		testEquals(3, MonitorResult.Status.CRITICAL.getSeverityRank());
+	}
+
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7958

## What Is Being Fixed

The check engine from LRCI-7816 produces `MonitorResult` objects, but nothing turns them into metrics, so the monitoring pipeline cannot see check state and cannot tell whether the monitor itself is alive.

## How It Is Being Fixed

`MonitorResult.Status` gains `getSeverityRank`, exposing the rank field the enum already carried. `MonitorMetricsWriter` takes a target file, a `MonitorResultStore`, and the registered monitor list, and `write()` emits three gauge families labeled with the check ID, type, and severity: `monitor_check_status` valued from the status rank, `monitor_check_last_run_timestamp_seconds`, and `monitor_heartbeat_timestamp_seconds`. Both timestamps are in seconds so the LRCI-7818 rules can compare them against `time()`. Publication is atomic, writing a sibling `.tmp` file in the metrics file's own directory and moving it over the target with `ATOMIC_MOVE`, so a scraper never reads a partial file and the temp file never matches node_exporter's `*.prom` glob.

Serialization goes through the official Prometheus Java client rather than assembling the exposition format by hand. `write()` builds three `GaugeSnapshot` instances and hands them to `PrometheusTextFormatWriter`, which owns the `# HELP` and `# TYPE` metadata, the label brace assembly, and the label value escaping. This adds `io.prometheus:prometheus-metrics-exposition-textformats:1.8.0`, whose two mandatory transitives bring the total to three jars and about 232 KB. Two output changes follow from the library and are spec valid: gauge values render as doubles (`3.0`, `1.75E9`), and metric families sort by name, so `monitor_check_last_run_timestamp_seconds` emits before `monitor_check_status`. Values round trip exactly, since epoch seconds sit far below the 2^53 exact integer ceiling.

Status comes from the result store rather than from what a cycle returned, so a check that was not due keeps its last known value and its series never disappears. The emitter is standalone rather than wired into `MonitorEngine`; LRCI-7821 composes `runCycle` and `write` and owns the file path.

`MonitorIdValidator` holds the monitor ID invariant, called from both `MonitorEngine`'s and `MonitorMetricsWriter`'s constructors. It rejects duplicate IDs, and null or empty ones. Duplicate IDs matter because `MonitorResultStore` is keyed on the ID alone, so two monitors sharing one share a single result slot and both would emit whichever result landed last, letting a critical check report as healthy. A null ID would otherwise reach `Labels.of` and throw out of `write()`. Rejecting at construction means no file is written at all rather than an invalid exposition or a half published one. Both constructors also copy the incoming list into an unmodifiable list, so the validated invariant holds for the object's lifetime rather than only at construction time.

Two further robustness fixes. A monitor returning a null status is treated as unknown rather than throwing, and a config falls back to `medium` for a null severity and to `unknown` for a null or empty type; previously a null would throw out of `write()` before the atomic move, leaving the last published file frozen and the heartbeat stalled, which alerting reads as staleness rather than as a loud failure. An empty type failed more quietly still: Prometheus treats a label with an empty value as equivalent to the label being absent, so the check would silently drop out of any grouping by type.

The emitted output was verified with `promtool check metrics` across seven shapes, including a never run check, an empty monitor list, and label values containing a quote, a backslash, a newline, a tab, and non ASCII characters. Details are recorded on LRCI-7958.

## Note For The Jar Bump

This adds a dependency, so it changes a jar published contract. After the module is published, `./gradlew generateDependencies` in `liferay-jenkins-ee` vendors the three jars into `lib/jenkins/`. Candidate jar testing before that publish needs the three added by hand, since the deploy path copies only the main jar.

## PR Check

**pr-check: PASS** — tested on `fb6b49a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "fb6b49a7c3da3c903ced80e180ae8cfc478d8ca1"} -->
