### PR TITLE
LPD-97349 Add CMS release test suite

### DIFF
--- a/ci.properties
+++ b/ci.properties
@@ -157,6 +157,7 @@ ci.test.available.suites=\
 ci.test.available.suites[test-portal-release]=\
     portal-release,\
     portal-release-acceptance,\
+    portal-release-cms,\
     portal-release-smoke
 
 ci.test.relevant.bypass.file.path.patterns=

--- a/test.properties
+++ b/test.properties
@@ -5526,7 +5526,7 @@
     #
     # Portal Release CMS
     #
-    
+
     playwright.projects.includes[playwright-js-tomcat101-*][portal-release-cms]=\
         e2e-cms-dxp.main,\
         site-cms-site-initializer.main,\
@@ -5541,9 +5541,9 @@
     test.batch.names[portal-release-cms]=\
         modules-integration-postgresql163,\
         playwright-js-tomcat101-postgresql163
-    
+
     test.release.bundle[portal-release-cms]=true
-    
+
     #
     # Portal Release Functional
     #

--- a/test.properties
+++ b/test.properties
@@ -5524,6 +5524,27 @@
     test.release.bundle[portal-release-acceptance]=true
 
     #
+    # Portal Release CMS
+    #
+    
+    playwright.projects.includes[playwright-js-tomcat101-*][portal-release-cms]=\
+        e2e-cms-dxp.main,\
+        site-cms-site-initializer.main,\
+        site-cms-site-initializer.permissions,\
+        site-cms-site-initializer.structure-builder
+
+    test.batch.class.names.includes[portal-release-cms]=\
+        **/site/site-cms-site-initializer-test/**/*Test.java
+
+    test.batch.dist.app.servers[portal-release-cms]=tomcat
+
+    test.batch.names[portal-release-cms]=\
+        modules-integration-postgresql163,\
+        playwright-js-tomcat101-postgresql163
+    
+    test.release.bundle[portal-release-cms]=true
+    
+    #
     # Portal Release Functional
     #
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97349

## What Is Being Fixed

CMS will be released as a standalone bundle. The primary testing for CMS will follow the usual test gates, however, the we would also like to be able to run a CMS test suite against the standalone bundle. At the moment only the following test suites can be run against a release bundle:
* portal-release-smoke, 
* portal-release, and,
* portal-release-acceptance 

The CMS Playwright projects and the `site-cms-site-initializer` integration tests were only reachable through the broader release test suites, so there was no way to run CMS-focused validation as its own pre-ship signal or to see CMS results isolated from the rest of a release run.

## How It Is Being Fixed

A new `portal-release-cms` suite is registered in `ci.properties` alongside the existing `portal-release` suites, and defined in `test.properties`. The suite pulls in the `e2e-cms-dxp.main` Playwright project together with the three `site-cms-site-initializer` projects covering the main flow, permissions, and the structure builder, and includes the `site-cms-site-initializer-test` integration test classes. It runs on Tomcat across the `modules-integration-postgresql163` and `playwright-js-tomcat101-postgresql163` batches, and is marked as a release bundle suite so it participates in release testing.

## Why Are There No Tests?

This change is limited to CI and test suite configuration properties and modifies no product code, so there is no behavior to cover with a new test.

## PR Check

**pr-check: PASS** — tested on `b9889280ea0d9fa6efbb102f1684cb6a7b274f6c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| PQL Validation | PASS |

<!-- pr-check {"result": "success", "sha": "b9889280ea0d9fa6efbb102f1684cb6a7b274f6c"} -->
